### PR TITLE
Add example to launch Xila and small refactoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ Drivers = { path = "Modules/Drivers", optional = true }
 Memory = { path = "Modules/Memory", optional = true }
 WASM = { path = "Modules/Executables/WASM", optional = true }
 Command_line_shell = { path = "Modules/Executables/Shell/Command_line", optional = true }
+Executable = { path = "Modules/Executable", optional = true }
+File_system = { path = "Modules/File_system", optional = true }
+Host_bindings = { path = "Modules/Bindings/Host", optional = true }
 
 [build-dependencies]
 Target = { path = "Modules/Target", optional = true }
@@ -69,5 +72,13 @@ Host = [
     "dep:WASM",
     "dep:Command_line_shell",
     "dep:Target",
+    "dep:Executable",
+    "dep:File_system",
+    "dep:Host_bindings",
 ]
 WASM = ["dep:WASM_bindings"]
+
+[[example]]
+name = "Native"
+path = "Examples/Native.rs"
+required-features = ["Host"]

--- a/Examples/Native.rs
+++ b/Examples/Native.rs
@@ -1,0 +1,107 @@
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+
+use Command_line_shell::Shell_executable_type;
+use Executable::Standard_type;
+use File_system::{Create_device, Create_file_system, Mode_type};
+use WASM::WASM_device_type;
+
+fn main() {
+    // - Initialize the system
+    // Initialize the task manager
+    Task::Initialize().unwrap();
+    // Initialize the users manager
+    Users::Initialize().unwrap();
+    // Initialize the time manager
+    Time::Initialize(Create_device!(Drivers::Native::Time_driver_type::New())).unwrap();
+    // - Initialize the graphics manager
+    // - - Initialize the graphics driver
+    const Resolution: Graphics::Point_type = Graphics::Point_type::New(800, 600);
+    let (Screen, Pointer) = Drivers::Native::Window_screen::New(Resolution).unwrap();
+    // - - Initialize the graphics manager
+    Graphics::Initialize();
+    // - - Add a screen
+    const Buffer_size: usize = Graphics::Get_recommended_buffer_size(&Resolution);
+    let _ = Graphics::Get_instance()
+        .Create_display::<Buffer_size>(Screen, Pointer, true)
+        .unwrap();
+
+    // - Initialize the file system
+    // Create a memory device
+    let Drive = Create_device!(Drivers::Native::File_drive_device_type::New(&"./Drive"));
+    // Mount the file system
+    let File_system = match LittleFS::File_system_type::New(Drive.clone(), 256) {
+        Ok(File_system) => File_system,
+        // If the file system is not found, format it
+        Err(_) => {
+            Drive
+                .Set_position(&File_system::Position_type::Start(0))
+                .unwrap();
+
+            LittleFS::File_system_type::Format(Drive.clone(), 256).unwrap();
+
+            LittleFS::File_system_type::New(Drive, 256).unwrap()
+        }
+    };
+    // Initialize the virtual file system
+    Virtual_file_system::Initialize(Create_file_system!(File_system));
+
+    // - - Mount the devices
+    let Task = Task::Get_instance().Get_current_task_identifier().unwrap();
+
+    Virtual_file_system::Get_instance()
+        .Mount_static_device(Task, &"/Shell", Create_device!(Shell_executable_type))
+        .unwrap();
+
+    Virtual_file_system::Get_instance()
+        .Mount_static_device(Task, &"/WASM", Create_device!(WASM_device_type))
+        .unwrap();
+
+    let _ = Virtual_file_system::Get_instance().Create_directory(&"/Devices", Task);
+
+    Drivers::Native::Console::Mount_devices(Task, Virtual_file_system::Get_instance()).unwrap();
+    // Initialize the virtual machine
+    Virtual_machine::Initialize(&[&Host_bindings::Graphics_bindings]);
+
+    // - Execute the shell
+    // - - Open the standard input, output and error
+    let Standard_in = Virtual_file_system::Get_instance()
+        .Open(&"/Devices/Standard_in", Mode_type::Read_only.into(), Task)
+        .unwrap();
+
+    let Standard_out = Virtual_file_system::Get_instance()
+        .Open(&"/Devices/Standard_out", Mode_type::Write_only.into(), Task)
+        .unwrap();
+
+    let Standard_error = Virtual_file_system::Get_instance()
+        .Open(
+            &"/Devices/Standard_error",
+            Mode_type::Write_only.into(),
+            Task,
+        )
+        .unwrap();
+
+    let Standard = Standard_type::New(
+        Standard_in,
+        Standard_out,
+        Standard_error,
+        Task,
+        Virtual_file_system::Get_instance(),
+    );
+    // - - Set the environment variables
+    Task::Get_instance()
+        .Set_environment_variable(Task, "Paths", "/")
+        .unwrap();
+
+    Task::Get_instance()
+        .Set_environment_variable(Task, "Host", "xila")
+        .unwrap();
+    // - - Execute the shell
+    let _ = Executable::Execute("/Shell", "".to_string(), Standard)
+        .unwrap()
+        .Join()
+        .unwrap();
+
+    Virtual_file_system::Uninitialize();
+}

--- a/Modules/Bindings/Host/Tests/Graphics.rs
+++ b/Modules/Bindings/Host/Tests/Graphics.rs
@@ -26,16 +26,18 @@ fn Integration_test() {
     let Memory_device = Create_device!(Memory_device_type::<512>::New(1024 * 512));
     LittleFS::File_system_type::Format(Memory_device.clone(), 512).unwrap();
 
-    let Virtual_file_system = Virtual_file_system::Initialize(Create_file_system!(
-        LittleFS::File_system_type::New(Memory_device, 256).unwrap()
-    ))
+    Virtual_file_system::Initialize(Create_file_system!(LittleFS::File_system_type::New(
+        Memory_device,
+        256
+    )
+    .unwrap()))
     .unwrap();
 
-    Virtual_file_system
+    Virtual_file_system::Get_instance()
         .Create_directory(&"/Devices", Task)
         .unwrap();
 
-    Drivers::Native::Console::Mount_devices(Task, Virtual_file_system).unwrap();
+    Drivers::Native::Console::Mount_devices(Task, Virtual_file_system::Get_instance()).unwrap();
 
     Virtual_machine::Initialize(&[&Host_bindings::Graphics_bindings]);
 
@@ -61,7 +63,7 @@ fn Integration_test() {
 
     let _Calendar = unsafe { lvgl::lv_calendar_create(Screen_object) };
 
-    let Standard_in = Virtual_file_system
+    let Standard_in = Virtual_file_system::Get_instance()
         .Open(
             &"/Devices/Standard_in",
             File_system::Mode_type::Read_only.into(),
@@ -69,7 +71,7 @@ fn Integration_test() {
         )
         .unwrap();
 
-    let Standard_out = Virtual_file_system
+    let Standard_out = Virtual_file_system::Get_instance()
         .Open(
             &"/Devices/Standard_out",
             File_system::Mode_type::Write_only.into(),
@@ -77,7 +79,7 @@ fn Integration_test() {
         )
         .unwrap();
 
-    let Standard_error = Virtual_file_system
+    let Standard_error = Virtual_file_system::Get_instance()
         .Open(
             &"/Devices/Standard_out",
             File_system::Mode_type::Write_only.into(),

--- a/Modules/Bindings/Host/src/Graphics.rs
+++ b/Modules/Bindings/Host/src/Graphics.rs
@@ -117,9 +117,11 @@ pub unsafe fn Call(
     let Lock = Instance.Lock();
 
     if Lock.is_ok() {
-        let _ = Pointer_table.get_or_init(Pointer_table_type::New);
+        let Pointer_table_reference = &raw mut Pointer_table;
 
-        let Pointer_table_reference = Pointer_table.get_mut().unwrap();
+        let _ = (*Pointer_table_reference).get_or_init(Pointer_table_type::New);
+
+        let Pointer_table_reference = (*Pointer_table_reference).get_mut().unwrap();
 
         Generated_bindings::Call_function(
             Environment,

--- a/Modules/Drivers/src/Native/Devices/Console.rs
+++ b/Modules/Drivers/src/Native/Devices/Console.rs
@@ -96,25 +96,25 @@ pub fn Mount_devices(
     Virtual_file_system: &Virtual_file_system_type,
 ) -> Result<(), String> {
     Virtual_file_system
-        .Mount_device(
+        .Mount_static_device(
             Task,
-            "/Devices/Standard_in",
+            &"/Devices/Standard_in",
             Create_device!(Standard_in_device_type),
         )
         .map_err(|Error| format!("Error adding standard in device: {:?}", Error))?;
 
     Virtual_file_system
-        .Mount_device(
+        .Mount_static_device(
             Task,
-            "/Devices/Standard_out",
+            &"/Devices/Standard_out",
             Create_device!(Standard_out_device_type),
         )
         .map_err(|Error| format!("Error adding standard out device: {:?}", Error))?;
 
     Virtual_file_system
-        .Mount_device(
+        .Mount_static_device(
             Task,
-            "/Devices/Standard_error",
+            &"/Devices/Standard_error",
             Create_device!(Standard_error_device_type),
         )
         .map_err(|Error| format!("Error adding standard error device: {:?}", Error))?;

--- a/Modules/Drivers/src/Native/Devices/Drive_file.rs
+++ b/Modules/Drivers/src/Native/Devices/Drive_file.rs
@@ -16,7 +16,7 @@ impl File_drive_device_type {
             .read(true)
             .write(true)
             .create(true)
-            .truncate(true)
+            .truncate(false)
             .open(Path)
             .expect("Error opening file");
 
@@ -44,13 +44,7 @@ impl Device_trait for File_drive_device_type {
     }
 
     fn Get_size(&self) -> File_system::Result_type<File_system::Size_type> {
-        self.0
-            .try_read()
-            .map_err(|_| Error_type::Ressource_busy)?
-            .metadata()
-            .map(|Metadata| Metadata.len())
-            .map(Size_type::New)
-            .map_err(|Error| Error.into())
+        Ok((1024 * 1024 * 1024 * 4_usize).into())
     }
 
     fn Set_position(
@@ -77,5 +71,52 @@ impl Device_trait for File_drive_device_type {
 
     fn Erase(&self) -> File_system::Result_type<()> {
         Ok(())
+    }
+
+    fn Get_block_size(&self) -> File_system::Result_type<usize> {
+        Ok(4096)
+    }
+}
+
+#[cfg(test)]
+mod Tests {
+    use super::*;
+    use File_system::Device_trait;
+
+    #[test]
+    fn Test_read_write() {
+        let File = File_drive_device_type::New(&"./Test");
+
+        let Data = [1, 2, 3, 4, 5];
+
+        assert_eq!(File.Write(&Data).unwrap(), Size_type::New(5));
+
+        File.Set_position(&File_system::Position_type::Start(0))
+            .unwrap();
+
+        let mut Buffer = [0; 5];
+
+        assert_eq!(File.Read(&mut Buffer).unwrap(), Size_type::New(5));
+        assert_eq!(Buffer, Data);
+    }
+
+    #[test]
+    fn Test_read_write_at_position() {
+        let File = File_drive_device_type::New(&"./Test");
+
+        File.Set_position(&File_system::Position_type::Start(10))
+            .unwrap();
+
+        let Data = [1, 2, 3, 4, 5];
+
+        assert_eq!(File.Write(&Data).unwrap(), Size_type::New(5));
+
+        File.Set_position(&File_system::Position_type::Start(10))
+            .unwrap();
+
+        let mut Buffer = [0; 5];
+
+        assert_eq!(File.Read(&mut Buffer).unwrap(), Size_type::New(5));
+        assert_eq!(Buffer, Data);
     }
 }

--- a/Modules/Drivers/src/Native/Devices/mod.rs
+++ b/Modules/Drivers/src/Native/Devices/mod.rs
@@ -17,11 +17,11 @@ pub fn Mount_devices(
     let (Screen, Pointer) = Window_screen::New(Resolution)?;
 
     Virtual_file_system
-        .Mount_device(Task, "/Devices/Screen", Screen)
+        .Mount_static_device(Task, &"/Devices/Screen", Screen)
         .map_err(|Error| format!("Error adding screen device: {:?}", Error))?;
 
     Virtual_file_system
-        .Mount_device(Task, "/Devices/Pointer", Pointer)
+        .Mount_static_device(Task, &"/Devices/Pointer", Pointer)
         .map_err(|Error| format!("Error adding pointer device: {:?}", Error))?;
 
     Console::Mount_devices(Task, Virtual_file_system)?;

--- a/Modules/Executables/Shell/Command_line/Tests/Integration_test.rs
+++ b/Modules/Executables/Shell/Command_line/Tests/Integration_test.rs
@@ -21,30 +21,29 @@ fn Integration_test() {
 
     let File_system = LittleFS::File_system_type::New(Memory_device, 256).unwrap();
 
-    let Virtual_file_system =
-        Virtual_file_system::Initialize(Create_file_system!(File_system)).unwrap();
+    Virtual_file_system::Initialize(Create_file_system!(File_system)).unwrap();
 
     let Task = Task_instance.Get_current_task_identifier().unwrap();
 
-    Virtual_file_system
-        .Mount_device(Task, "/Shell", Create_device!(Shell_executable_type))
+    Virtual_file_system::Get_instance()
+        .Mount_static_device(Task, &"/Shell", Create_device!(Shell_executable_type))
         .unwrap();
 
-    Virtual_file_system
+    Virtual_file_system::Get_instance()
         .Create_directory(&"/Devices", Task)
         .unwrap();
 
-    Drivers::Native::Console::Mount_devices(Task, Virtual_file_system).unwrap();
+    Drivers::Native::Console::Mount_devices(Task, Virtual_file_system::Get_instance()).unwrap();
 
-    let Standard_in = Virtual_file_system
+    let Standard_in = Virtual_file_system::Get_instance()
         .Open(&"/Devices/Standard_in", Mode_type::Read_only.into(), Task)
         .unwrap();
 
-    let Standard_out = Virtual_file_system
+    let Standard_out = Virtual_file_system::Get_instance()
         .Open(&"/Devices/Standard_out", Mode_type::Write_only.into(), Task)
         .unwrap();
 
-    let Standard_error = Virtual_file_system
+    let Standard_error = Virtual_file_system::Get_instance()
         .Open(
             &"/Devices/Standard_error",
             Mode_type::Write_only.into(),
@@ -57,7 +56,7 @@ fn Integration_test() {
         Standard_out,
         Standard_error,
         Task,
-        Virtual_file_system,
+        Virtual_file_system::Get_instance(),
     );
 
     Task_instance

--- a/Modules/Executables/Shell/Command_line/Tests/Integration_test.rs
+++ b/Modules/Executables/Shell/Command_line/Tests/Integration_test.rs
@@ -65,10 +65,6 @@ fn Integration_test() {
         .unwrap();
 
     Task_instance
-        .Set_environment_variable(Task, "User", "alix_anneraud")
-        .unwrap();
-
-    Task_instance
         .Set_environment_variable(Task, "Host", "xila")
         .unwrap();
 

--- a/Modules/Executables/Shell/Command_line/src/Commands/Authentication.rs
+++ b/Modules/Executables/Shell/Command_line/src/Commands/Authentication.rs
@@ -1,0 +1,19 @@
+use crate::{Result_type, Shell_type};
+
+impl Shell_type {
+    pub fn Authenticate(&mut self) -> Result_type<String> {
+        self.Standard.Print("Username: ");
+        self.Standard.Out_flush();
+
+        let mut Username = String::new();
+        self.Standard.Read_line(&mut Username);
+
+        self.Standard.Print("Password: ");
+        self.Standard.Out_flush();
+
+        let mut Password = String::new();
+        self.Standard.Read_line(&mut Password);
+
+        Ok(Username)
+    }
+}

--- a/Modules/Executables/Shell/Command_line/src/Commands/mod.rs
+++ b/Modules/Executables/Shell/Command_line/src/Commands/mod.rs
@@ -1,3 +1,4 @@
+mod Authentication;
 mod Change_directory;
 mod Clear;
 mod Concatenate;

--- a/Modules/Executables/Shell/Command_line/src/Error.rs
+++ b/Modules/Executables/Shell/Command_line/src/Error.rs
@@ -6,7 +6,9 @@ pub type Result_type<T> = Result<T, Error_type>;
 #[derive(Debug, Clone)]
 #[repr(u16)]
 pub enum Error_type {
-    Failed_to_tokenize_command_line = 1,
+    Authentication_failed = 1,
+    Failed_to_set_environment_variable,
+    Failed_to_tokenize_command_line,
     Missing_file_name_after_redirect_out,
     Missing_file_name_after_redirect_in,
     Missing_command,
@@ -17,12 +19,15 @@ pub enum Error_type {
     Failed_to_execute_command,
     Failed_to_join_task,
     Invalid_number_of_arguments,
-    Todo,
 }
 
 impl Display for Error_type {
     fn fmt(&self, Formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
+            Error_type::Authentication_failed => write!(Formatter, "Authentication failed"),
+            Error_type::Failed_to_set_environment_variable => {
+                write!(Formatter, "Failed to set environment variable")
+            }
             Error_type::Failed_to_tokenize_command_line => {
                 write!(Formatter, "Failed to tokenize command line")
             }
@@ -48,7 +53,6 @@ impl Display for Error_type {
             Error_type::Invalid_number_of_arguments => {
                 write!(Formatter, "Invalid number of arguments")
             }
-            Error_type::Todo => write!(Formatter, "Todo"),
         }
     }
 }

--- a/Modules/Executables/WASM/Tests/Integration_test.rs
+++ b/Modules/Executables/WASM/Tests/Integration_test.rs
@@ -33,34 +33,33 @@ fn Integration_test() {
         .Load(&mut File_system)
         .unwrap();
 
-    let Virtual_file_system =
-        Virtual_file_system::Initialize(Create_file_system!(File_system)).unwrap();
+    Virtual_file_system::Initialize(Create_file_system!(File_system)).unwrap();
 
     let Task = Task_instance.Get_current_task_identifier().unwrap();
 
-    Virtual_file_system
-        .Mount_device(Task, "/Shell", Create_device!(Shell_executable_type))
+    Virtual_file_system::Get_instance()
+        .Mount_static_device(Task, &"/Shell", Create_device!(Shell_executable_type))
         .unwrap();
 
-    Virtual_file_system
-        .Mount_device(Task, "/WASM", Create_device!(WASM_device_type))
+    Virtual_file_system::Get_instance()
+        .Mount_static_device(Task, &"/WASM", Create_device!(WASM_device_type))
         .unwrap();
 
-    Virtual_file_system
+    Virtual_file_system::Get_instance()
         .Create_directory(&"/Devices", Task)
         .unwrap();
 
-    Drivers::Native::Console::Mount_devices(Task, Virtual_file_system).unwrap();
+    Drivers::Native::Console::Mount_devices(Task, Virtual_file_system::Get_instance()).unwrap();
 
-    let Standard_in = Virtual_file_system
+    let Standard_in = Virtual_file_system::Get_instance()
         .Open(&"/Devices/Standard_in", Mode_type::Read_only.into(), Task)
         .unwrap();
 
-    let Standard_out = Virtual_file_system
+    let Standard_out = Virtual_file_system::Get_instance()
         .Open(&"/Devices/Standard_out", Mode_type::Write_only.into(), Task)
         .unwrap();
 
-    let Standard_error = Virtual_file_system
+    let Standard_error = Virtual_file_system::Get_instance()
         .Open(
             &"/Devices/Standard_error",
             Mode_type::Write_only.into(),
@@ -73,7 +72,7 @@ fn Integration_test() {
         Standard_out,
         Standard_error,
         Task,
-        Virtual_file_system,
+        Virtual_file_system::Get_instance(),
     );
 
     Task_instance

--- a/Modules/File_system/src/Fundamentals/Path/Components.rs
+++ b/Modules/File_system/src/Fundamentals/Path/Components.rs
@@ -43,7 +43,7 @@ impl<'a> Iterator for Components_type<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for Components_type<'a> {
+impl DoubleEndedIterator for Components_type<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.0.next_back().map(Component_type::from)
     }

--- a/Modules/Graphics/Tests/Graphics.rs
+++ b/Modules/Graphics/Tests/Graphics.rs
@@ -50,7 +50,7 @@ fn main() {
     unsafe {
         lvgl::lv_obj_set_align(Slider, lvgl::lv_align_t_LV_ALIGN_LEFT_MID);
         lvgl::lv_obj_set_align(Button, lvgl::lv_align_t_LV_ALIGN_CENTER);
-        lvgl::lv_label_set_text(Label, "Hello world!\0".as_ptr() as *const i8);
+        lvgl::lv_label_set_text(Label, c"Hello world!".as_ptr());
     }
 
     loop {

--- a/Modules/Graphics/Tests/Graphics.rs
+++ b/Modules/Graphics/Tests/Graphics.rs
@@ -11,7 +11,7 @@ fn main() {
     use Graphics::{lvgl, Get_recommended_buffer_size, Point_type};
     use Time::Duration_type;
 
-    Users::Initialize().expect("Error initializing users manager");
+    let _ = Users::Initialize();
 
     let Task_instance = Task::Initialize().expect("Error initializing task manager");
 

--- a/Modules/Graphics/src/Manager.rs
+++ b/Modules/Graphics/src/Manager.rs
@@ -14,10 +14,15 @@ use crate::{Error_type, Input_type, Result_type, Screen_read_data_type};
 
 static Manager_instance: OnceLock<Manager_type> = OnceLock::new();
 
-pub fn Initialize() -> &'static Manager_type {
-    let Manager = Manager_instance.get_or_init(|| {
-        Manager_type::New(Time::Get_instance()).expect("Failed to create manager instance")
-    });
+pub fn Initialize() {
+    Manager_instance
+        .set(Manager_type::New(Time::Get_instance()).expect("Failed to create manager instance"))
+        .map_err(|_| ())
+        .expect(
+            "
+         Graphics manager was already initialized
+        ",
+        );
 
     let Task_instance = Task::Get_instance();
 
@@ -27,12 +32,10 @@ pub fn Initialize() -> &'static Manager_type {
             "Graphics",
             None,
             move || {
-                Manager.Loop().unwrap();
+                Get_instance().Loop().unwrap();
             },
         )
         .unwrap();
-
-    Manager
 }
 
 pub fn Get_instance() -> &'static Manager_type {

--- a/Modules/Graphics/src/Screen.rs
+++ b/Modules/Graphics/src/Screen.rs
@@ -14,13 +14,13 @@ impl<'a> Screen_write_data_type<'a> {
     }
 }
 
-impl<'a> AsRef<[u8]> for Screen_write_data_type<'a> {
+impl AsRef<[u8]> for Screen_write_data_type<'_> {
     fn as_ref(&self) -> &[u8] {
         unsafe { std::slice::from_raw_parts(self as *const _ as *const u8, size_of::<Self>()) }
     }
 }
 
-impl<'a> TryFrom<&[u8]> for &Screen_write_data_type<'a> {
+impl TryFrom<&[u8]> for &Screen_write_data_type<'_> {
     type Error = ();
 
     /// This function is used to convert a buffer of bytes to a struct.
@@ -51,7 +51,7 @@ impl<'a> TryFrom<&[u8]> for &Screen_write_data_type<'a> {
     }
 }
 
-impl<'a> Screen_write_data_type<'a> {
+impl Screen_write_data_type<'_> {
     pub fn Get_area(&self) -> Area_type {
         self.Area
     }

--- a/Modules/Users/src/Manager.rs
+++ b/Modules/Users/src/Manager.rs
@@ -1,34 +1,22 @@
 use super::*;
 use std::{
     collections::{BTreeMap, BTreeSet},
-    sync::RwLock,
+    sync::{OnceLock, RwLock},
     vec::Vec,
 };
 
-static mut Manager_instance: Option<Manager_type> = None;
+static Manager_instance: OnceLock<Manager_type> = OnceLock::new();
 
-pub fn Initialize() -> Result_type<&'static Manager_type> {
-    if Is_initialized() {
-        return Err(Error_type::Already_initialized);
-    }
-
-    unsafe {
-        Manager_instance = Some(Manager_type::New());
-    }
-
-    Ok(Get_instance())
+pub fn Initialize() -> Result_type<()> {
+    Manager_instance
+        .set(Manager_type::New())
+        .map_err(|_| Error_type::Already_initialized)
 }
 
 pub fn Get_instance() -> &'static Manager_type {
-    unsafe {
-        Manager_instance
-            .as_ref()
-            .expect("Users manager not initialized")
-    }
-}
-
-pub fn Is_initialized() -> bool {
-    unsafe { Manager_instance.is_some() }
+    Manager_instance
+        .get()
+        .expect("Users manager not initialized")
 }
 
 struct Internal_user_type {

--- a/Modules/Virtual_file_system/Tests/Integration.rs
+++ b/Modules/Virtual_file_system/Tests/Integration.rs
@@ -147,7 +147,7 @@ fn Test_device() {
     let Device = Create_device!(Memory_device_type::<512>::New(512));
 
     Virtual_file_system
-        .Mount_device(Task, Device_path, Device)
+        .Mount_static_device(Task, &Device_path, Device)
         .unwrap();
 
     let Device_file = File_type::Open(

--- a/Modules/Virtual_file_system/src/Error.rs
+++ b/Modules/Virtual_file_system/src/Error.rs
@@ -1,0 +1,11 @@
+#[derive(Debug)]
+pub enum Error_type {
+    Already_initialized,
+    File_system(File_system::Error_type),
+}
+
+impl From<File_system::Error_type> for Error_type {
+    fn from(Value: File_system::Error_type) -> Self {
+        Self::File_system(Value)
+    }
+}

--- a/Modules/Virtual_file_system/src/File.rs
+++ b/Modules/Virtual_file_system/src/File.rs
@@ -19,7 +19,7 @@ pub struct File_type<'a> {
     Task: Task_identifier_type,
 }
 
-impl<'a> Debug for File_type<'a> {
+impl Debug for File_type<'_> {
     fn fmt(&self, Formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Formatter
             .debug_struct("File_type")
@@ -121,7 +121,7 @@ impl<'a> File_type<'a> {
     }
 }
 
-impl<'a> Drop for File_type<'a> {
+impl Drop for File_type<'_> {
     fn drop(&mut self) {
         let _ = self
             .File_system

--- a/Modules/Virtual_file_system/src/File_system.rs
+++ b/Modules/Virtual_file_system/src/File_system.rs
@@ -186,9 +186,9 @@ impl Virtual_file_system_type {
             return Err(Error_type::Invalid_path);
         }
 
-        let File_system_identifier = {
-            let File_systems = self.File_systems.read()?; // Get the file systems
+        let mut File_systems = self.File_systems.write()?; // Get the file systems
 
+        let File_system_identifier = {
             let (File_system_identifier, _, Relative_path) =
                 Self::Get_file_system_from_path(&File_systems, &Path)?; // Get the file system identifier and the relative path
 
@@ -198,8 +198,6 @@ impl Virtual_file_system_type {
 
             File_system_identifier
         };
-
-        let mut File_systems = self.File_systems.write()?;
 
         let File_system = File_systems
             .remove(&File_system_identifier)
@@ -574,10 +572,10 @@ impl Virtual_file_system_type {
         Ok(())
     }
 
-    pub fn Mount_device(
+    pub fn Mount_static_device(
         &self,
         Task: Task_identifier_type,
-        Path: impl AsRef<Path_type> + 'static,
+        Path: &'static impl AsRef<Path_type>,
         Device: Device_type,
     ) -> Result_type<()> {
         let File_systems = self.File_systems.read()?; // Get the file systems
@@ -613,7 +611,7 @@ impl Virtual_file_system_type {
         };
 
         // Create the actual device.
-        let Inode = self.Device_file_system.Mount_device(Device)?;
+        let Inode = self.Device_file_system.Mount_static_device(Path, Device)?;
 
         let Time: Time_type = Time::Get_instance()
             .Get_current_time()

--- a/Modules/Virtual_file_system/src/lib.rs
+++ b/Modules/Virtual_file_system/src/lib.rs
@@ -3,9 +3,11 @@
 #![allow(non_upper_case_globals)]
 
 mod Device;
+mod Error;
 mod File;
 mod File_system;
 mod Pipe;
 
+pub use Error::*;
 pub use File::*;
 pub use File_system::*;

--- a/Modules/Virtual_machine/Tests/Test.rs
+++ b/Modules/Virtual_machine/Tests/Test.rs
@@ -39,18 +39,18 @@ fn Integration_test() {
     LittleFS::File_system_type::Format(Device.clone(), 512).unwrap();
     let File_system = Create_file_system!(LittleFS::File_system_type::New(Device, 256).unwrap());
 
-    let Virtual_file_system = Virtual_file_system::Initialize(File_system).unwrap();
+    Virtual_file_system::Initialize(File_system).unwrap();
 
     // Set environment variables
     let Task = Task_instance.Get_current_task_identifier().unwrap();
 
-    Virtual_file_system
+    Virtual_file_system::Get_instance()
         .Create_directory(&"/Devices", Task)
         .unwrap();
 
     Drivers::Native::Console::Mount_devices(
         Task_instance.Get_current_task_identifier().unwrap(),
-        Virtual_file_system,
+        Virtual_file_system::Get_instance(),
     )
     .unwrap();
 
@@ -69,21 +69,21 @@ fn Integration_test() {
         .Build()
         .unwrap();
 
-    let Standard_in = Virtual_file_system
+    let Standard_in = Virtual_file_system::Get_instance()
         .Open(
             &"/Devices/Standard_in",
             File_system::Mode_type::Read_only.into(),
             Task,
         )
         .expect("Failed to open stdin");
-    let Standard_out = Virtual_file_system
+    let Standard_out = Virtual_file_system::Get_instance()
         .Open(
             &"/Devices/Standard_out",
             File_system::Mode_type::Write_only.into(),
             Task,
         )
         .expect("Failed to open stdout");
-    let Standard_error = Virtual_file_system
+    let Standard_error = Virtual_file_system::Get_instance()
         .Open(
             &"/Devices/Standard_error",
             File_system::Mode_type::Write_only.into(),
@@ -91,7 +91,7 @@ fn Integration_test() {
         )
         .expect("Failed to open stderr");
 
-    let (Standard_in, Standard_out, Standard_error) = Virtual_file_system
+    let (Standard_in, Standard_out, Standard_error) = Virtual_file_system::Get_instance()
         .Create_new_task_standard_io(Standard_in, Standard_error, Standard_out, Task, Task, false)
         .unwrap();
 

--- a/Modules/Virtual_machine/src/Environment.rs
+++ b/Modules/Virtual_machine/src/Environment.rs
@@ -27,7 +27,7 @@ unsafe impl Send for Environment_type<'_> {}
 
 unsafe impl Sync for Environment_type<'_> {}
 
-impl<'a> Environment_type<'a> {
+impl Environment_type<'_> {
     pub fn From_raw_pointer(Raw_pointer: Environment_pointer_type) -> Result_type<Self> {
         if Raw_pointer.is_null() {
             return Err(Error_type::Invalid_pointer);

--- a/Modules/Virtual_machine/src/Module.rs
+++ b/Modules/Virtual_machine/src/Module.rs
@@ -12,7 +12,7 @@ pub struct Module_type<'runtime> {
 
 unsafe impl Send for Module_type<'_> {}
 
-const Directory_paths: [&CStr; 1] = [unsafe { CStr::from_bytes_with_nul_unchecked(b"/\0") }];
+const Directory_paths: [&CStr; 1] = [c"/"];
 const Directory_paths_raw: [*const i8; 1] = [Directory_paths[0].as_ptr()];
 
 impl<'runtime> Module_type<'runtime> {


### PR DESCRIPTION
- **Add authentication command to shell module**
- **Refactor error handling and input parsing in shell module; add authentication error type**
- **Refactor device management in virtual file system; enhance Mount_device to accept static paths and add Get_devices_from_path method**
- **Refactor graphics module to improve pointer table initialization and access**
- **Refactor File_drive_device_type to adjust truncate behavior and implement Get_block_size method; add unit tests for read/write functionality**
- **Add Native.rs example**
- **Refactor lifetime parameters in various implementations to use '_ instead of explicit lifetimes**
- **Add error handling for virtual file system initialization and implement uninitialization method**
- **Refactor user manager initialization to use OnceLock for thread-safe instance management**
- **Remove hardcoded user environment variable from integration test**
- **Refactor graphics manager initialization to handle multiple initializations and improve error handling**
- **Use new c"" literal for C string**
- **Refactor virtual file system to improve file system access and rename Mount_device to Mount_static_device**
- **Refactor virtual file system interactions to use Mount_static_device for improved clarity and consistency**
- **Add new optional modules for Executable, File_system, and Host_bindings in Cargo.toml**
