### PR TITLE
fix: adjust virtual keyboard size ratio based on screen type

### DIFF
--- a/examples/wasm/src/main.rs
+++ b/examples/wasm/src/main.rs
@@ -235,7 +235,9 @@ async fn main() {
 
     bootsplash.stop(graphics_manager).await.unwrap();
 
-    let arguments = if drivers_wasm::devices::graphics::has_touch_screen().unwrap() {
+    let has_touch_screen = drivers_wasm::devices::graphics::has_touch_screen().unwrap_or(false);
+
+    let arguments = if has_touch_screen {
         log::information!("Touch screen detected.");
         vec!["--show-keyboard".to_string()]
     } else {


### PR DESCRIPTION
This pull request introduces several improvements to the graphical shell layout, focusing on better handling of touch screen detection, keyboard sizing, and header organization. The main changes include safer detection of touch screens, dynamic keyboard height adjustment, and a refactored header layout to use a flex tray for right-side elements like WiFi and battery indicators.

**Touch screen detection and keyboard sizing:**

* Replaced direct `unwrap()` usage with `unwrap_or(false)` for touch screen detection in `main.rs`, preventing potential panics if the result is `None`.
* Dynamically sets the keyboard height based on its width and a new `KEYBOARD_SIZE_RATIO` constant, ensuring consistent appearance across different screen sizes. [[1]](diffhunk://#diff-f93ee0f9c3aae8b47d6dce81bb83a4d9b8825486e5e06f72de60ebe5c4168ea7L6-R8) [[2]](diffhunk://#diff-f93ee0f9c3aae8b47d6dce81bb83a4d9b8825486e5e06f72de60ebe5c4168ea7L82-R92)

**Header layout refactor:**

* Introduced a flex tray object in the header for right-side elements, improving layout flexibility and maintainability. The tray uses flex row flow and padding for better spacing.
* Updated creation of WiFi and battery labels to be children of the new tray instead of the header, aligning them properly and simplifying their positioning logic.