### PR TITLE
217 implement proccpuinfo like device

### DIFF
--- a/drivers/std/src/devices/cpu.rs
+++ b/drivers/std/src/devices/cpu.rs
@@ -1,0 +1,177 @@
+use file_system::{
+    DirectBaseOperations, DirectCharacterDevice, Error, MountOperations, Result, Size,
+};
+use std::collections::BTreeMap;
+
+const EMBEDDED_FIELDS: [&str; 6] = [
+    "processor",
+    "vendor_id",
+    "model name",
+    "cpu MHz",
+    "cpu cores",
+    "architecture",
+];
+
+pub struct CpuInformationsDevice;
+
+fn parse_proc_cpuinfo(content: &str) -> Vec<BTreeMap<String, String>> {
+    let mut entries = Vec::new();
+    let mut current = BTreeMap::new();
+
+    for line in content.lines() {
+        let line = line.trim();
+
+        if line.is_empty() {
+            if !current.is_empty() {
+                entries.push(current);
+                current = BTreeMap::new();
+            }
+            continue;
+        }
+
+        if let Some((key, value)) = line.split_once(':') {
+            current.insert(key.trim().to_string(), value.trim().to_string());
+        }
+    }
+
+    if !current.is_empty() {
+        entries.push(current);
+    }
+
+    entries
+}
+
+fn format_entry(
+    entry: &BTreeMap<String, String>,
+    index: usize,
+    architecture: &str,
+    fallback_cores: &str,
+) -> String {
+    let mut block = String::new();
+
+    for key in EMBEDDED_FIELDS {
+        let value = match key {
+            "processor" => entry.get(key).cloned().unwrap_or_else(|| index.to_string()),
+            "architecture" => architecture.to_string(),
+            "cpu cores" => entry
+                .get(key)
+                .cloned()
+                .unwrap_or_else(|| fallback_cores.to_string()),
+            _ => entry
+                .get(key)
+                .cloned()
+                .unwrap_or_else(|| "unknown".to_string()),
+        };
+
+        block.push_str(key);
+        block.push_str("\t: ");
+        block.push_str(&value);
+        block.push('\n');
+    }
+
+    block.push('\n');
+    block
+}
+
+fn build_cpuinfo_text_from_proc(
+    content: &str,
+    architecture: &str,
+    available_cores: Option<usize>,
+) -> String {
+    let parsed = parse_proc_cpuinfo(content);
+    let fallback_cores = available_cores
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    if parsed.is_empty() {
+        return format_entry(&BTreeMap::new(), 0, architecture, &fallback_cores);
+    }
+
+    let mut output = String::new();
+    for (index, entry) in parsed.iter().enumerate() {
+        output.push_str(&format_entry(entry, index, architecture, &fallback_cores));
+    }
+
+    output
+}
+
+fn render_cpuinfo_text() -> String {
+    let architecture = std::env::consts::ARCH;
+    let cores = std::thread::available_parallelism().ok().map(usize::from);
+
+    if cfg!(target_os = "linux") {
+        if let Ok(content) = std::fs::read_to_string("/proc/cpuinfo") {
+            return build_cpuinfo_text_from_proc(&content, architecture, cores);
+        }
+    }
+
+    build_cpuinfo_text_from_proc("", architecture, cores)
+}
+
+impl DirectBaseOperations for CpuInformationsDevice {
+    fn read(&self, buffer: &mut [u8], absolute_position: Size) -> Result<usize> {
+        let content = render_cpuinfo_text();
+        let bytes = content.as_bytes();
+
+        let start = usize::try_from(absolute_position).unwrap_or(usize::MAX);
+        if start >= bytes.len() {
+            return Ok(0);
+        }
+
+        let length = buffer.len().min(bytes.len() - start);
+        buffer[..length].copy_from_slice(&bytes[start..start + length]);
+
+        Ok(length)
+    }
+
+    fn write(&self, _: &[u8], _: Size) -> Result<usize> {
+        Err(Error::UnsupportedOperation)
+    }
+}
+
+impl MountOperations for CpuInformationsDevice {}
+
+impl DirectCharacterDevice for CpuInformationsDevice {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parser_extracts_embedded_subset_fields() {
+        let sample = "processor\t: 0\nvendor_id\t: ARM\nmodel name\t: Cortex-A53\ncpu MHz\t\t: 1200.0\ncpu cores\t: 4\n\n";
+        let output = build_cpuinfo_text_from_proc(sample, "aarch64", Some(4));
+        assert!(output.contains("processor\t: 0"));
+        assert!(output.contains("vendor_id\t: ARM"));
+        assert!(output.contains("model name\t: Cortex-A53"));
+        assert!(output.contains("cpu MHz\t: 1200.0"));
+        assert!(output.contains("cpu cores\t: 4"));
+        assert!(output.contains("architecture\t: aarch64"));
+    }
+
+    #[test]
+    fn parser_falls_back_to_unknown_for_missing_values() {
+        let output = build_cpuinfo_text_from_proc("", "aarch64", None);
+        assert!(output.contains("vendor_id\t: unknown"));
+        assert!(output.contains("cpu MHz\t: unknown"));
+        assert!(output.contains("cpu cores\t: unknown"));
+    }
+
+    #[test]
+    fn read_uses_absolute_offset_and_handles_eof() {
+        let device = CpuInformationsDevice;
+        let mut buffer = [0u8; 32];
+        let first = device.read(&mut buffer, 0).unwrap();
+        assert!(first > 0);
+
+        let eof = device.read(&mut buffer, Size::MAX).unwrap();
+        assert_eq!(eof, 0);
+    }
+
+    #[test]
+    fn write_is_not_supported() {
+        let device = CpuInformationsDevice;
+        let result = device.write(b"ignored", 0);
+        assert!(matches!(result, Err(Error::UnsupportedOperation)));
+    }
+}

--- a/drivers/std/src/devices/mod.rs
+++ b/drivers/std/src/devices/mod.rs
@@ -1,3 +1,5 @@
+mod cpu;
 mod time;
 
+pub use cpu::*;
 pub use time::*;

--- a/drivers/wasm/src/devices/cpu.rs
+++ b/drivers/wasm/src/devices/cpu.rs
@@ -1,0 +1,110 @@
+use alloc::string::{String, ToString};
+use file_system::{
+    DirectBaseOperations, DirectCharacterDevice, Error, MountOperations, Result, Size,
+};
+
+pub struct CpuInformationsDevice;
+
+fn get_hardware_concurrency() -> Option<u32> {
+    let window = web_sys::window()?;
+    let navigator = window.navigator();
+    let value = js_sys::Reflect::get(
+        &navigator,
+        &wasm_bindgen::JsValue::from_str("hardwareConcurrency"),
+    )
+    .ok()?;
+    let value = value.as_f64()?;
+
+    if !value.is_finite() || value <= 0.0 {
+        return None;
+    }
+
+    Some(value as u32)
+}
+
+fn build_cpuinfo_text(architecture: &str, hardware_concurrency: Option<u32>) -> String {
+    let cores = hardware_concurrency
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let mut content = String::new();
+    content.push_str("processor\t: 0\n");
+    content.push_str("vendor_id\t: unknown\n");
+    content.push_str("model name\t: unknown\n");
+    content.push_str("cpu MHz\t: unknown\n");
+    content.push_str("cpu cores\t: ");
+    content.push_str(&cores);
+    content.push('\n');
+    content.push_str("architecture\t: ");
+    content.push_str(architecture);
+    content.push_str("\n\n");
+    content
+}
+
+fn render_cpuinfo_text() -> String {
+    build_cpuinfo_text("wasm32", get_hardware_concurrency())
+}
+
+impl DirectBaseOperations for CpuInformationsDevice {
+    fn read(&self, buffer: &mut [u8], absolute_position: Size) -> Result<usize> {
+        let content = render_cpuinfo_text();
+        let bytes = content.as_bytes();
+
+        let start = usize::try_from(absolute_position).unwrap_or(usize::MAX);
+        if start >= bytes.len() {
+            return Ok(0);
+        }
+
+        let length = buffer.len().min(bytes.len() - start);
+        buffer[..length].copy_from_slice(&bytes[start..start + length]);
+
+        Ok(length)
+    }
+
+    fn write(&self, _: &[u8], _: Size) -> Result<usize> {
+        Err(Error::UnsupportedOperation)
+    }
+}
+
+impl MountOperations for CpuInformationsDevice {}
+
+impl DirectCharacterDevice for CpuInformationsDevice {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formatter_uses_unknown_for_missing_values() {
+        let output = build_cpuinfo_text("wasm32", None);
+        assert!(output.contains("vendor_id\t: unknown"));
+        assert!(output.contains("model name\t: unknown"));
+        assert!(output.contains("cpu MHz\t: unknown"));
+        assert!(output.contains("cpu cores\t: unknown"));
+        assert!(output.contains("architecture\t: wasm32"));
+    }
+
+    #[test]
+    fn formatter_includes_detected_cores() {
+        let output = build_cpuinfo_text("wasm32", Some(8));
+        assert!(output.contains("cpu cores\t: 8"));
+    }
+
+    #[test]
+    fn read_uses_absolute_offset_and_handles_eof() {
+        let device = CpuInformationsDevice;
+        let mut buffer = [0u8; 24];
+        let first = device.read(&mut buffer, 0).unwrap();
+        assert!(first > 0);
+
+        let eof = device.read(&mut buffer, Size::MAX).unwrap();
+        assert_eq!(eof, 0);
+    }
+
+    #[test]
+    fn write_is_not_supported() {
+        let device = CpuInformationsDevice;
+        let result = device.write(b"ignored", 0);
+        assert!(matches!(result, Err(Error::UnsupportedOperation)));
+    }
+}

--- a/drivers/wasm/src/devices/mod.rs
+++ b/drivers/wasm/src/devices/mod.rs
@@ -1,8 +1,10 @@
+mod cpu;
 mod drive;
 pub mod graphics;
 mod http_client;
 mod time;
 
+pub use cpu::*;
 pub use drive::*;
 pub use http_client::*;
 pub use time::*;

--- a/examples/native/src/main.rs
+++ b/examples/native/src/main.rs
@@ -118,6 +118,9 @@ async fn main() {
 
     // - - Create the default system hierarchy
     let _ = virtual_file_system::create_default_hierarchy(virtual_file_system, task).await;
+    let _ = virtual_file_system
+        .create_directory(task, "/devices/cpu")
+        .await;
 
     log::information!("Default hierarchy created.");
 
@@ -144,6 +147,11 @@ async fn main() {
                 &"/devices/time",
                 CharacterDevice,
                 drivers_std::devices::TimeDevice
+            ),
+            (
+                &"/devices/cpu/informations",
+                CharacterDevice,
+                drivers_std::devices::CpuInformationsDevice
             ),
             (
                 &"/devices/random",

--- a/examples/native/src/main.rs
+++ b/examples/native/src/main.rs
@@ -119,7 +119,7 @@ async fn main() {
     // - - Create the default system hierarchy
     let _ = virtual_file_system::create_default_hierarchy(virtual_file_system, task).await;
     let _ = virtual_file_system
-        .create_directory(task, "/devices/cpu")
+        .create_directory(task, &"/devices/cpu")
         .await;
 
     log::information!("Default hierarchy created.");

--- a/examples/wasm/src/main.rs
+++ b/examples/wasm/src/main.rs
@@ -101,6 +101,9 @@ async fn main() {
 
     // - - Create the default system hierarchy
     let _ = virtual_file_system::create_default_hierarchy(virtual_file_system, task).await;
+    let _ = virtual_file_system
+        .create_directory(task, "/devices/cpu")
+        .await;
 
     // - - Mount the devices
     virtual_file_system::clean_devices(virtual_file_system, task)
@@ -130,6 +133,11 @@ async fn main() {
                 &"/devices/time",
                 CharacterDevice,
                 drivers_wasm::devices::TimeDevice
+            ),
+            (
+                &"/devices/cpu/informations",
+                CharacterDevice,
+                drivers_wasm::devices::CpuInformationsDevice
             ),
             (
                 &"/devices/random",

--- a/examples/wasm/src/main.rs
+++ b/examples/wasm/src/main.rs
@@ -102,7 +102,7 @@ async fn main() {
     // - - Create the default system hierarchy
     let _ = virtual_file_system::create_default_hierarchy(virtual_file_system, task).await;
     let _ = virtual_file_system
-        .create_directory(task, "/devices/cpu")
+        .create_directory(task, &"/devices/cpu")
         .await;
 
     // - - Mount the devices

--- a/executables/settings/locales/en.json
+++ b/executables/settings/locales/en.json
@@ -3,6 +3,7 @@
   "Address": "Address",
   "Apply": "Apply",
   "Authentication failed: {}": "Authentication failed: {}",
+  "CPU:": "CPU:",
   "Cancel": "Cancel",
   "Change Password": "Change Password",
   "Configuration Mode": "Configuration Mode",

--- a/executables/settings/locales/fr.json
+++ b/executables/settings/locales/fr.json
@@ -3,6 +3,7 @@
   "Address": "Adresse",
   "Apply": "Appliquer",
   "Authentication failed: {}": "Échec de l'authentification: {}",
+  "CPU:": "Processeur :",
   "Cancel": "Annuler",
   "Change Password": "Changer le mot de passe",
   "Configuration Mode": "Mode de configuration",

--- a/executables/settings/src/tabs/about.rs
+++ b/executables/settings/src/tabs/about.rs
@@ -1,6 +1,6 @@
 use crate::error::Result;
-use alloc::{ffi::CString, format};
-use core::{ffi::CStr, ptr::null_mut};
+use alloc::{ffi::CString, format, string::ToString, vec::Vec};
+use core::{ffi::CStr, ptr::null_mut, str};
 use xila::{
     about,
     graphics::{
@@ -10,6 +10,8 @@ use xila::{
     internationalization::{self, translate},
     memory,
     shared::{BYTES_SUFFIX, Unit},
+    task,
+    virtual_file_system::{self, File},
 };
 
 pub struct AboutTab {
@@ -81,7 +83,52 @@ impl AboutTab {
             .map_err(|_| crate::error::Error::FailedToCreateUiElement)?;
         self.create_list_item(translate!(c"Memory:"), &memory)?;
 
+        let cpu_summary = CString::new(Self::get_cpu_summary().await)
+            .map_err(|_| crate::error::Error::FailedToCreateUiElement)?;
+        self.create_list_item(translate!(c"CPU:"), &cpu_summary)?;
+
         Ok(self.container)
+    }
+
+    async fn get_cpu_summary() -> alloc::string::String {
+        let virtual_file_system = virtual_file_system::get_instance();
+        let task = task::get_instance().get_current_task_identifier().await;
+
+        let mut buffer = Vec::new();
+
+        if File::read_from_path(
+            virtual_file_system,
+            task,
+            "/devices/cpu/informations",
+            &mut buffer,
+        )
+        .await
+        .is_err()
+        {
+            return "unknown (unknown cores, unknown)".to_string();
+        }
+
+        let content = str::from_utf8(&buffer).unwrap_or_default();
+
+        let model_name = Self::get_cpu_info_value(content, "model name").unwrap_or("unknown");
+        let cpu_cores = Self::get_cpu_info_value(content, "cpu cores").unwrap_or("unknown");
+        let architecture = Self::get_cpu_info_value(content, "architecture").unwrap_or("unknown");
+
+        format!("{} ({} cores, {})", model_name, cpu_cores, architecture)
+    }
+
+    fn get_cpu_info_value<'a>(content: &'a str, key: &str) -> Option<&'a str> {
+        for line in content.lines() {
+            let Some((line_key, line_value)) = line.split_once(':') else {
+                continue;
+            };
+
+            if line_key.trim() == key {
+                return Some(line_value.trim());
+            }
+        }
+
+        None
     }
 
     fn create_list_item(&mut self, name: &CStr, value: &CStr) -> Result<()> {

--- a/modules/testing/src/lib.rs
+++ b/modules/testing/src/lib.rs
@@ -81,7 +81,7 @@ pub async fn initialize(graphics_enabled: bool, network_enabled: bool) -> Standa
         .unwrap();
 
     let _ = virtual_file_system
-        .create_directory(task, "/devices/cpu")
+        .create_directory(task, &"/devices/cpu")
         .await;
 
     virtual_file_system

--- a/modules/testing/src/lib.rs
+++ b/modules/testing/src/lib.rs
@@ -80,6 +80,10 @@ pub async fn initialize(graphics_enabled: bool, network_enabled: bool) -> Standa
         .await
         .unwrap();
 
+    let _ = virtual_file_system
+        .create_directory(task, "/devices/cpu")
+        .await;
+
     virtual_file_system
         .mount_static(
             task,
@@ -151,6 +155,11 @@ pub async fn initialize(graphics_enabled: bool, network_enabled: bool) -> Standa
                 &"/devices/time",
                 CharacterDevice,
                 drivers_std::devices::TimeDevice
+            ),
+            (
+                &"/devices/cpu/informations",
+                CharacterDevice,
+                drivers_std::devices::CpuInformationsDevice
             ),
             (&"/devices/null", CharacterDevice, drivers_core::NullDevice),
             (


### PR DESCRIPTION
This pull request introduces a new virtual CPU information device for both native and WebAssembly (WASM) environments, exposes it in the virtual file system, and integrates it into the system's initialization and the Settings application's About tab. This enables users and applications to retrieve standardized CPU information (such as model, core count, and architecture) via a virtual file, improving system introspection and portability.

**New CPU Information Device**

* Added `CpuInformationsDevice` implementation for both native (`drivers/std/src/devices/cpu.rs`) and WASM (`drivers/wasm/src/devices/cpu.rs`) targets, providing a `/devices/cpu/informations` character device that outputs formatted CPU details. The native version parses `/proc/cpuinfo` when available, while the WASM version uses browser APIs to estimate core count. Both fallback gracefully to "unknown" when data is missing. [[1]](diffhunk://#diff-2ea51a773de418f7729ee9ddb2d5005a49ba29a7727fe70c77ef0e31e59c9a4aR1-R177) [[2]](diffhunk://#diff-89fddd89982914d06fbf27e6916f2853c6bc7634b1a1f5dcac9f7ba3287abd2fR1-R110)
* Updated device module exports to include the new CPU device in both native and WASM drivers. [[1]](diffhunk://#diff-073da0471f330a20cf92e635fe0469cfc1ce334f3726a380e84548c93bd7d425R1-R4) [[2]](diffhunk://#diff-ff6eb4e4665a42c640106638f4d4b9362efeb2255db9c2ae3080f8c676488bc9R1-R7)

**Virtual File System Integration**

* Modified system initialization in native, WASM, and test environments to create the `/devices/cpu` directory and mount the new `CpuInformationsDevice` at `/devices/cpu/informations`. [[1]](diffhunk://#diff-34ce9b412c8ab411a5cec57b3eceda59f9a7052a97c0b0e59f9d147d0fc3e50aR121-R123) [[2]](diffhunk://#diff-34ce9b412c8ab411a5cec57b3eceda59f9a7052a97c0b0e59f9d147d0fc3e50aR151-R155) [[3]](diffhunk://#diff-f4d1998423cac25d98268e8c6b0182df962fc5e08ad868ad72b56ea8462b4b21R104-R106) [[4]](diffhunk://#diff-f4d1998423cac25d98268e8c6b0182df962fc5e08ad868ad72b56ea8462b4b21R137-R141) [[5]](diffhunk://#diff-d28b3eb3e6227fd0a00d53e2c59b969497eab629965ec669734a4b6f58414f9dR83-R86) [[6]](diffhunk://#diff-d28b3eb3e6227fd0a00d53e2c59b969497eab629965ec669734a4b6f58414f9dR159-R163)

**Settings Application Enhancement**

* Updated the Settings application's About tab to asynchronously read from `/devices/cpu/informations` and display a summary of the CPU model, core count, and architecture, improving the user's visibility into system hardware. [[1]](diffhunk://#diff-1f839b747a52b7cee74f2db81f94d3be05468ba985f24d643af141fdff905c07L2-R3) [[2]](diffhunk://#diff-1f839b747a52b7cee74f2db81f94d3be05468ba985f24d643af141fdff905c07R13-R14) [[3]](diffhunk://#diff-1f839b747a52b7cee74f2db81f94d3be05468ba985f24d643af141fdff905c07R86-R133)

**Testing and Robustness**

* Included comprehensive unit tests for the new device implementations, covering parsing, formatting, reading with offsets, and error handling for unsupported writes. [[1]](diffhunk://#diff-2ea51a773de418f7729ee9ddb2d5005a49ba29a7727fe70c77ef0e31e59c9a4aR1-R177) [[2]](diffhunk://#diff-89fddd89982914d06fbf27e6916f2853c6bc7634b1a1f5dcac9f7ba3287abd2fR1-R110)