### PR TITLE
implement rm and rmdir commands in command line shell

### DIFF
--- a/executables/shell/command_line/src/commands/directory.rs
+++ b/executables/shell/command_line/src/commands/directory.rs
@@ -3,14 +3,15 @@ use alloc::borrow::ToOwned;
 use executable_macros::GetArgs;
 use getargs::Options;
 use xila::{
-    file_system::Path,
+    file_system::{Kind, Path},
     virtual_file_system::{self, Directory},
 };
 
 use super::{CommandContext, UserCommand};
 
 pub struct CreateDirectoryCommand;
-pub struct RemoveCommand;
+pub struct RemoveFileCommand;
+pub struct RemoveDirectoryCommand;
 
 impl UserCommand for CreateDirectoryCommand {
     async fn execute<'a, I, C>(
@@ -27,7 +28,7 @@ impl UserCommand for CreateDirectoryCommand {
     }
 }
 
-impl UserCommand for RemoveCommand {
+impl UserCommand for RemoveFileCommand {
     async fn execute<'a, I, C>(
         &self,
         context: &mut C,
@@ -38,7 +39,22 @@ impl UserCommand for RemoveCommand {
         I: Iterator<Item = &'a str>,
         C: CommandContext,
     {
-        execute_remove(context, options).await
+        execute_remove_file(context, options).await
+    }
+}
+
+impl UserCommand for RemoveDirectoryCommand {
+    async fn execute<'a, I, C>(
+        &self,
+        context: &mut C,
+        options: &mut Options<&'a str, I>,
+        _paths: &[&Path],
+    ) -> Result<()>
+    where
+        I: Iterator<Item = &'a str>,
+        C: CommandContext,
+    {
+        execute_remove_directory(context, options).await
     }
 }
 
@@ -73,6 +89,14 @@ fn resolve_path<C: CommandContext>(
     }
 }
 
+fn can_remove_with_rm(kind: Kind) -> bool {
+    kind != Kind::Directory
+}
+
+fn can_remove_with_rmdir(kind: Kind) -> bool {
+    kind == Kind::Directory
+}
+
 async fn execute_create_directory<'a, I, C>(
     context: &mut C,
     options: &mut Options<&'a str, I>,
@@ -94,14 +118,51 @@ where
     .map_err(Error::FailedToCreateDirectory)
 }
 
-async fn execute_remove<'a, I, C>(context: &mut C, options: &mut Options<&'a str, I>) -> Result<()>
+async fn execute_remove_file<'a, I, C>(
+    context: &mut C,
+    options: &mut Options<&'a str, I>,
+) -> Result<()>
 where
     I: Iterator<Item = &'a str>,
     C: CommandContext,
 {
     let DirectoryRemoveArguments { path } = DirectoryRemoveArguments::parse(options)?;
-
     let path = resolve_path(context, path)?;
+
+    let statistics = virtual_file_system::get_instance()
+        .get_statistics(&path)
+        .await
+        .map_err(Error::FailedToGetMetadata)?;
+
+    if !can_remove_with_rm(statistics.kind) {
+        return Err(Error::InvalidArgument);
+    }
+
+    virtual_file_system::get_instance()
+        .remove(context.task_id(), &path)
+        .await
+        .map_err(Error::FailedToRemoveDirectory)
+}
+
+async fn execute_remove_directory<'a, I, C>(
+    context: &mut C,
+    options: &mut Options<&'a str, I>,
+) -> Result<()>
+where
+    I: Iterator<Item = &'a str>,
+    C: CommandContext,
+{
+    let DirectoryRemoveArguments { path } = DirectoryRemoveArguments::parse(options)?;
+    let path = resolve_path(context, path)?;
+
+    let statistics = virtual_file_system::get_instance()
+        .get_statistics(&path)
+        .await
+        .map_err(Error::FailedToGetMetadata)?;
+
+    if !can_remove_with_rmdir(statistics.kind) {
+        return Err(Error::InvalidArgument);
+    }
 
     virtual_file_system::get_instance()
         .remove(context.task_id(), &path)
@@ -111,13 +172,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_path;
+    use super::{can_remove_with_rm, can_remove_with_rmdir, resolve_path};
     use crate::{Error, Result};
     use alloc::borrow::ToOwned;
     use core::fmt;
     use xila::{
         executable::Standard,
-        file_system::{Path, PathOwned},
+        file_system::{Kind, Path, PathOwned},
         task::TaskIdentifier,
     };
 
@@ -184,5 +245,21 @@ mod tests {
         let result = resolve_path(&context, "bad path");
 
         assert!(matches!(result, Err(Error::InvalidPath)));
+    }
+
+    #[test]
+    fn rm_rejects_directories() {
+        assert!(!can_remove_with_rm(Kind::Directory));
+    }
+
+    #[test]
+    fn rm_accepts_files() {
+        assert!(can_remove_with_rm(Kind::File));
+    }
+
+    #[test]
+    fn rmdir_accepts_directories_only() {
+        assert!(can_remove_with_rmdir(Kind::Directory));
+        assert!(!can_remove_with_rmdir(Kind::File));
     }
 }

--- a/executables/shell/command_line/src/commands/mod.rs
+++ b/executables/shell/command_line/src/commands/mod.rs
@@ -29,7 +29,7 @@ use self::{
     change_directory::ChangeDirectoryCommand,
     clear::ClearCommand,
     concatenate::ConcatenateCommand,
-    directory::{CreateDirectoryCommand, RemoveCommand},
+    directory::{CreateDirectoryCommand, RemoveDirectoryCommand, RemoveFileCommand},
     dns::DnsResolveCommand,
     echo::EchoCommand,
     environment_variables::{
@@ -87,7 +87,8 @@ pub enum UserCommandKind {
     CreateDirectory,
     SetEnvironmentVariable,
     RemoveEnvironmentVariable,
-    Remove,
+    RemoveFile,
+    RemoveDirectory,
     WebRequest,
     DnsResolve,
     Ping,
@@ -112,7 +113,8 @@ pub fn resolve_user_command(name: &str) -> Option<UserCommandKind> {
         "mkdir" => Some(UserCommandKind::CreateDirectory),
         "export" => Some(UserCommandKind::SetEnvironmentVariable),
         "unset" => Some(UserCommandKind::RemoveEnvironmentVariable),
-        "rm" => Some(UserCommandKind::Remove),
+        "rm" => Some(UserCommandKind::RemoveFile),
+        "rmdir" => Some(UserCommandKind::RemoveDirectory),
         "web_request" => Some(UserCommandKind::WebRequest),
         "dns_resolve" => Some(UserCommandKind::DnsResolve),
         "ping" => Some(UserCommandKind::Ping),
@@ -164,7 +166,12 @@ where
                 .execute(context, options, paths)
                 .await
         }
-        UserCommandKind::Remove => RemoveCommand.execute(context, options, paths).await,
+        UserCommandKind::RemoveFile => RemoveFileCommand.execute(context, options, paths).await,
+        UserCommandKind::RemoveDirectory => {
+            RemoveDirectoryCommand
+                .execute(context, options, paths)
+                .await
+        }
         UserCommandKind::WebRequest => WebRequestCommand.execute(context, options, paths).await,
         UserCommandKind::DnsResolve => DnsResolveCommand.execute(context, options, paths).await,
         UserCommandKind::Ping => PingCommand.execute(context, options, paths).await,
@@ -245,7 +252,11 @@ mod tests {
         ));
         assert!(matches!(
             resolve_user_command("rm"),
-            Some(UserCommandKind::Remove)
+            Some(UserCommandKind::RemoveFile)
+        ));
+        assert!(matches!(
+            resolve_user_command("rmdir"),
+            Some(UserCommandKind::RemoveDirectory)
         ));
         assert!(matches!(
             resolve_user_command("web_request"),


### PR DESCRIPTION
This pull request refactors the handling of file and directory removal commands in the shell command line module. The main improvement is splitting the previous generic `RemoveCommand` into two distinct commands: one for files (`RemoveFileCommand`/`rm`) and one for directories (`RemoveDirectoryCommand`/`rmdir`). This change ensures that each command validates the type of the target (file or directory) before attempting removal, preventing accidental misuse and aligning behavior with typical Unix shell semantics.

**Command separation and validation:**

* Split the previous `RemoveCommand` into `RemoveFileCommand` (for `rm`) and `RemoveDirectoryCommand` (for `rmdir`), each with its own implementation and validation logic. Now, `rm` will only remove files, and `rmdir` will only remove directories, with appropriate error handling if the type does not match. [[1]](diffhunk://#diff-a749538a7099b2eee95a00ebab6975bac5443e78905125ed9e1d91da421c7ce3L6-R14) [[2]](diffhunk://#diff-a749538a7099b2eee95a00ebab6975bac5443e78905125ed9e1d91da421c7ce3L30-R31) [[3]](diffhunk://#diff-a749538a7099b2eee95a00ebab6975bac5443e78905125ed9e1d91da421c7ce3L41-R57) [[4]](diffhunk://#diff-a749538a7099b2eee95a00ebab6975bac5443e78905125ed9e1d91da421c7ce3L97-R166) [[5]](diffhunk://#diff-a749538a7099b2eee95a00ebab6975bac5443e78905125ed9e1d91da421c7ce3R92-R99)
* Added helper functions `can_remove_with_rm` and `can_remove_with_rmdir` to encapsulate the logic for determining if a path can be removed by `rm` or `rmdir`, respectively.

**Command registration and dispatch:**

* Updated the command registration and dispatch logic to recognize and correctly route `rm` to `RemoveFileCommand` and `rmdir` to `RemoveDirectoryCommand`. The `UserCommandKind` enum and related resolution logic were updated accordingly. [[1]](diffhunk://#diff-ad68f93c5ef4db31f9d212ba856a73db41b43f9edf105905a7b6229fb2384036L32-R32) [[2]](diffhunk://#diff-ad68f93c5ef4db31f9d212ba856a73db41b43f9edf105905a7b6229fb2384036L90-R91) [[3]](diffhunk://#diff-ad68f93c5ef4db31f9d212ba856a73db41b43f9edf105905a7b6229fb2384036L115-R117) [[4]](diffhunk://#diff-ad68f93c5ef4db31f9d212ba856a73db41b43f9edf105905a7b6229fb2384036L167-R174)

**Testing improvements:**

* Added new unit tests to verify that `rm` rejects directories and accepts files, and that `rmdir` only accepts directories, ensuring the new validation logic works as intended. [[1]](diffhunk://#diff-a749538a7099b2eee95a00ebab6975bac5443e78905125ed9e1d91da421c7ce3R249-R264) [[2]](diffhunk://#diff-ad68f93c5ef4db31f9d212ba856a73db41b43f9edf105905a7b6229fb2384036L248-R259)