### PR TITLE
Implement waker for UI events processing

### DIFF
--- a/executables/file_manager/src/file_manager.rs
+++ b/executables/file_manager/src/file_manager.rs
@@ -96,6 +96,8 @@ impl FileManager {
             }
         });
 
+        self.window.yield_now().await;
+
         self.running
     }
 

--- a/executables/file_manager/src/lib.rs
+++ b/executables/file_manager/src/lib.rs
@@ -62,9 +62,7 @@ pub async fn main(_: Standard, _: Vec<String>) -> core::result::Result<(), NonZe
         .await
         .map_err(|_| NonZeroUsize::new(1).unwrap())?;
 
-    while file_manager.handle_events().await {
-        task::sleep(Duration::from_millis(50)).await;
-    }
+    while file_manager.handle_events().await {}
 
     Ok(())
 }

--- a/executables/file_manager/src/lib.rs
+++ b/executables/file_manager/src/lib.rs
@@ -8,9 +8,7 @@ mod file_manager;
 use alloc::boxed::Box;
 use alloc::string::{String, ToString};
 use core::num::NonZeroUsize;
-use core::time::Duration;
 use xila::executable::{self, ExecutableTrait, Standard};
-use xila::task;
 use xila::task::TaskIdentifier;
 use xila::virtual_file_system::{File, VirtualFileSystem};
 

--- a/executables/settings/src/lib.rs
+++ b/executables/settings/src/lib.rs
@@ -12,9 +12,11 @@ pub use settings::*;
 
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
+use core::future::poll_fn;
 use core::num::NonZeroUsize;
 use core::time::Duration;
 use xila::executable::{self, ExecutableTrait, Standard};
+use xila::log;
 use xila::task;
 use xila::task::TaskIdentifier;
 use xila::virtual_file_system::{File, VirtualFileSystem};
@@ -70,9 +72,7 @@ pub async fn main(_: Standard, _: Vec<String>) -> core::result::Result<(), NonZe
         .map_err(|_| NonZeroUsize::new(1).unwrap())?;
 
     // Run the main loop
-    while settings.handle_events().await {
-        task::sleep(Duration::from_millis(50)).await;
-    }
+    while settings.handle_events().await {}
 
     Ok(())
 }

--- a/executables/settings/src/lib.rs
+++ b/executables/settings/src/lib.rs
@@ -12,12 +12,8 @@ pub use settings::*;
 
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
-use core::future::poll_fn;
 use core::num::NonZeroUsize;
-use core::time::Duration;
 use xila::executable::{self, ExecutableTrait, Standard};
-use xila::log;
-use xila::task;
 use xila::task::TaskIdentifier;
 use xila::virtual_file_system::{File, VirtualFileSystem};
 

--- a/executables/settings/src/settings.rs
+++ b/executables/settings/src/settings.rs
@@ -1,12 +1,17 @@
+use core::future::poll_fn;
+use core::task::Poll;
+
 use alloc::string::String;
 use xila::file_system::Kind;
 use xila::graphics::{
     self, EventKind, Window, lvgl,
     palette::{self, Hue},
 };
+use xila::log;
+use xila::task::yield_now;
 
 use crate::error::Result;
-use crate::tabs::{AboutTab, GeneralTab, NetworkTab, PasswordTab, Tab};
+use crate::tabs::{self, AboutTab, GeneralTab, NetworkTab, PasswordTab, Tab};
 
 pub struct Settings {
     window: Window,
@@ -56,25 +61,25 @@ impl Settings {
     }
 
     pub async fn handle_events(&mut self) -> bool {
-        let mut running = true;
-
         graphics::lock!({
             while let Some(event) = self.window.pop_event() {
+                // Logique de filtrage spécifique à Settings
                 if (event.code == EventKind::Delete || event.code == EventKind::CloseRequested)
                     && event.target == self.window.get_object()
                 {
-                    running = false;
-                } else {
-                    // Let each tab handle the event
-                    for tab in &mut self.tabs {
-                        if tab.handle_event(&event).await {
-                            break; // Event was handled, no need to check other tabs
-                        }
+                    return false;
+                }
+
+                for tab in &mut self.tabs {
+                    if tab.handle_event(&event).await {
+                        break;
                     }
                 }
             }
         });
 
-        running
+        self.window.yield_now().await;
+
+        true
     }
 }

--- a/executables/settings/src/settings.rs
+++ b/executables/settings/src/settings.rs
@@ -1,17 +1,12 @@
-use core::future::poll_fn;
-use core::task::Poll;
-
 use alloc::string::String;
 use xila::file_system::Kind;
 use xila::graphics::{
     self, EventKind, Window, lvgl,
     palette::{self, Hue},
 };
-use xila::log;
-use xila::task::yield_now;
 
 use crate::error::Result;
-use crate::tabs::{self, AboutTab, GeneralTab, NetworkTab, PasswordTab, Tab};
+use crate::tabs::{AboutTab, GeneralTab, NetworkTab, PasswordTab, Tab};
 
 pub struct Settings {
     window: Window,

--- a/modules/graphics/src/window.rs
+++ b/modules/graphics/src/window.rs
@@ -2,14 +2,17 @@ use super::lvgl;
 use crate::{Color, Error, EventKind, Result, event::Event};
 use alloc::boxed::Box;
 use alloc::collections::VecDeque;
-use core::{mem::forget, str};
+use core::{future::poll_fn, mem::forget, str, task::Poll};
+use synchronization::waitqueue::AtomicWaker;
 
 struct UserData {
     pub queue: VecDeque<Event>,
     pub icon_text: [u8; 2],
     pub icon_color: Color,
+    pub waker_registration: AtomicWaker,
 }
 
+#[derive(Clone)]
 pub struct Window {
     window: *mut lvgl::lv_obj_t,
 }
@@ -34,7 +37,7 @@ unsafe extern "C" fn event_callback(event: *mut lvgl::lv_event_t) {
     unsafe {
         let code = lvgl::lv_event_get_code(event);
 
-        let queue = lvgl::lv_event_get_user_data(event) as *mut VecDeque<Event>;
+        let user_data = lvgl::lv_event_get_user_data(event) as *mut UserData;
 
         let target = lvgl::lv_event_get_target(event) as *mut lvgl::lv_obj_t;
 
@@ -42,7 +45,10 @@ unsafe extern "C" fn event_callback(event: *mut lvgl::lv_event_t) {
             lvgl::lv_event_code_t_LV_EVENT_CHILD_CREATED => {
                 lvgl::lv_obj_add_flag(target, lvgl::lv_obj_flag_t_LV_OBJ_FLAG_EVENT_BUBBLE);
 
-                (*queue).push_back(Event::new(EventKind::ChildCreated, target, None));
+                (*user_data)
+                    .queue
+                    .push_back(Event::new(EventKind::ChildCreated, target, None));
+                (*user_data).waker_registration.wake();
             }
             lvgl::lv_event_code_t_LV_EVENT_DRAW_MAIN
             | lvgl::lv_event_code_t_LV_EVENT_DRAW_MAIN_BEGIN
@@ -51,16 +57,25 @@ unsafe extern "C" fn event_callback(event: *mut lvgl::lv_event_t) {
             | lvgl::lv_event_code_t_LV_EVENT_DRAW_POST_BEGIN
             | lvgl::lv_event_code_t_LV_EVENT_DRAW_POST_END
             | lvgl::lv_event_code_t_LV_EVENT_GET_SELF_SIZE
-            | lvgl::lv_event_code_t_LV_EVENT_COVER_CHECK => {
+            | lvgl::lv_event_code_t_LV_EVENT_COVER_CHECK
+            | lvgl::lv_event_code_t_LV_EVENT_LAYOUT_CHANGED => {
                 // Ignore draw events
             }
             lvgl::lv_event_code_t_LV_EVENT_KEY => {
                 let key = lvgl::lv_indev_get_key(lvgl::lv_indev_active());
 
-                (*queue).push_back(Event::new(EventKind::Key, target, Some(key.into())));
+                (*user_data)
+                    .queue
+                    .push_back(Event::new(EventKind::Key, target, Some(key.into())));
+                (*user_data).waker_registration.wake();
             }
             _ => {
-                (*queue).push_back(Event::new(EventKind::from_lvgl_code(code), target, None));
+                (*user_data).queue.push_back(Event::new(
+                    EventKind::from_lvgl_code(code),
+                    target,
+                    None,
+                ));
+                (*user_data).waker_registration.wake();
             }
         }
     }
@@ -96,6 +111,7 @@ impl Window {
             queue: VecDeque::with_capacity(10),
             icon_text: [b'I', b'c'],
             icon_color: Color::BLACK,
+            waker_registration: AtomicWaker::new(),
         };
 
         let mut user_data = Box::new(user_data);
@@ -192,6 +208,14 @@ impl Window {
         user_data.icon_color = icon_color;
     }
 
+    pub fn register_waker(&mut self, waker: &core::task::Waker) {
+        let user_data = unsafe { lvgl::lv_obj_get_user_data(self.window) as *mut UserData };
+
+        let user_data = unsafe { &mut *user_data };
+
+        user_data.waker_registration.register(waker);
+    }
+
     /// Convert a raw pointer to a window object.
     ///
     /// # Returns
@@ -204,6 +228,19 @@ impl Window {
     ///
     pub unsafe fn from_raw(window: *mut lvgl::lv_obj_t) -> Self {
         Self { window }
+    }
+
+    pub fn yield_now(&mut self) -> impl core::future::Future<Output = ()> + '_ {
+        let mut yielded = false;
+        poll_fn(move |cx| {
+            if yielded {
+                Poll::Ready(())
+            } else {
+                self.register_waker(cx.waker());
+                yielded = true;
+                Poll::Pending
+            }
+        })
     }
 
     pub fn into_raw(self) -> *mut lvgl::lv_obj_t {


### PR DESCRIPTION
This pull request introduces improvements to the event handling and asynchronous behavior of the `Window` system, especially in the `file_manager` and `settings` executables. The main changes center around making event loops more responsive by removing fixed sleep intervals and implementing an async waker-based system for UI event processing. Additionally, the `Window` struct is extended to support async yielding, allowing tasks to efficiently wait for new UI events.

**Event loop and async improvements:**

* Replaced the fixed `task::sleep` delay in the main event loops of `file_manager` and `settings` with an efficient, event-driven approach—now the loops simply await `handle_events()` without sleeping, improving responsiveness and reducing unnecessary wakeups. [[1]](diffhunk://#diff-cd71dec4ab18cc5b94b9f62b2c076019c290d06daae06217c9c6e12e78088ebbL65-R65) [[2]](diffhunk://#diff-92bcfe8d9c4dc95dad9cfc61a3178ffc6ecc00238345409beac1b92314a26ff4L73-R75)
* Modified the `handle_events` method in both `FileManager` and `Settings` to use the new `window.yield_now().await` mechanism, which asynchronously yields until new events are available, instead of relying on polling and sleeping. [[1]](diffhunk://#diff-a75d455434caa56d5729d0c661e75d3398d79c177e1c1699d2b6561932d2c7bfR99-R100) [[2]](diffhunk://#diff-1ec65bb0c09489a0995d4d07ff9663cbefbddc2205105dab3146e627f3baaf2eL59-R83)

**Window struct and event system enhancements:**

* Added a waker registration system to `Window` using an `AtomicWaker`, and updated event callbacks to wake any registered waker when new events arrive. This enables efficient async notification of UI events. [[1]](diffhunk://#diff-fba6a207a369554e4ab627381332fca03d18a4775fda136079bc8ffa016cb72cL5-R15) [[2]](diffhunk://#diff-fba6a207a369554e4ab627381332fca03d18a4775fda136079bc8ffa016cb72cL37-R51) [[3]](diffhunk://#diff-fba6a207a369554e4ab627381332fca03d18a4775fda136079bc8ffa016cb72cL54-R78) [[4]](diffhunk://#diff-fba6a207a369554e4ab627381332fca03d18a4775fda136079bc8ffa016cb72cR114) [[5]](diffhunk://#diff-fba6a207a369554e4ab627381332fca03d18a4775fda136079bc8ffa016cb72cR211-R218)
* Introduced the `yield_now` async method on `Window`, which returns a future that resolves when the next event is available, integrating seamlessly with async/await.

**Minor codebase maintenance:**

* Added missing imports (`poll_fn`, `log`, etc.) and minor refactoring for clarity and future extensibility in `settings.rs` and related files. [[1]](diffhunk://#diff-92bcfe8d9c4dc95dad9cfc61a3178ffc6ecc00238345409beac1b92314a26ff4R15-R19) [[2]](diffhunk://#diff-1ec65bb0c09489a0995d4d07ff9663cbefbddc2205105dab3146e627f3baaf2eR1-R14)

These changes collectively make the UI event system more efficient and idiomatic for async Rust, improving both responsiveness and power efficiency.