### PR TITLE
228 refactor graphics::window into lvgl component

### DIFF
--- a/drivers/shared/src/devices/http_common.rs
+++ b/drivers/shared/src/devices/http_common.rs
@@ -22,25 +22,24 @@ pub fn map_network_error(error: network::Error) -> Error {
 }
 
 pub fn split_host_port(host_value: &str, default_port: u16) -> (&str, u16) {
-    if let Some(stripped) = host_value.strip_prefix('[') {
-        if let Some(end) = stripped.find(']') {
-            let host = &stripped[..end];
-            let remainder = &stripped[end + 1..];
-            if let Some(port_string) = remainder.strip_prefix(':') {
-                if let Ok(port) = port_string.parse::<u16>() {
-                    return (host, port);
-                }
-            }
-            return (host, default_port);
+    if let Some(stripped) = host_value.strip_prefix('[')
+        && let Some(end) = stripped.find(']')
+    {
+        let host = &stripped[..end];
+        let remainder = &stripped[end + 1..];
+        if let Some(port_string) = remainder.strip_prefix(':')
+            && let Ok(port) = port_string.parse::<u16>()
+        {
+            return (host, port);
         }
+        return (host, default_port);
     }
 
-    if let Some((host, port_string)) = host_value.rsplit_once(':') {
-        if !host.contains(':') {
-            if let Ok(port) = port_string.parse::<u16>() {
-                return (host, port);
-            }
-        }
+    if let Some((host, port_string)) = host_value.rsplit_once(':')
+        && !host.contains(':')
+        && let Ok(port) = port_string.parse::<u16>()
+    {
+        return (host, port);
     }
 
     (host_value, default_port)

--- a/drivers/std/src/devices/cpu.rs
+++ b/drivers/std/src/devices/cpu.rs
@@ -99,10 +99,10 @@ fn render_cpuinfo_text() -> String {
     let architecture = std::env::consts::ARCH;
     let cores = std::thread::available_parallelism().ok().map(usize::from);
 
-    if cfg!(target_os = "linux") {
-        if let Ok(content) = std::fs::read_to_string("/proc/cpuinfo") {
-            return build_cpuinfo_text_from_proc(&content, architecture, cores);
-        }
+    if cfg!(target_os = "linux")
+        && let Ok(content) = std::fs::read_to_string("/proc/cpuinfo")
+    {
+        return build_cpuinfo_text_from_proc(&content, architecture, cores);
     }
 
     build_cpuinfo_text_from_proc("", architecture, cores)

--- a/drivers/wasm/src/devices/graphics/keyboard.rs
+++ b/drivers/wasm/src/devices/graphics/keyboard.rs
@@ -80,12 +80,13 @@ impl KeyboardDevice {
 
         let paste_closure = Closure::wrap(Box::new(move |event: ClipboardEvent| {
             if let Some(clipboard_data) = event.clipboard_data()
-                && let Ok(text) = clipboard_data.get_data("text") {
-                    for char in text.chars() {
-                        Self::handle_key_press_char(sender, char, true);
-                        Self::handle_key_press_char(sender, char, false);
-                    }
+                && let Ok(text) = clipboard_data.get_data("text")
+            {
+                for char in text.chars() {
+                    Self::handle_key_press_char(sender, char, true);
+                    Self::handle_key_press_char(sender, char, false);
                 }
+            }
         }) as Box<dyn FnMut(ClipboardEvent)>);
 
         window

--- a/drivers/wasm/src/devices/graphics/keyboard.rs
+++ b/drivers/wasm/src/devices/graphics/keyboard.rs
@@ -79,14 +79,13 @@ impl KeyboardDevice {
         let sender = inner.0.sender();
 
         let paste_closure = Closure::wrap(Box::new(move |event: ClipboardEvent| {
-            if let Some(clipboard_data) = event.clipboard_data() {
-                if let Ok(text) = clipboard_data.get_data("text") {
+            if let Some(clipboard_data) = event.clipboard_data()
+                && let Ok(text) = clipboard_data.get_data("text") {
                     for char in text.chars() {
                         Self::handle_key_press_char(sender, char, true);
                         Self::handle_key_press_char(sender, char, false);
                     }
                 }
-            }
         }) as Box<dyn FnMut(ClipboardEvent)>);
 
         window

--- a/drivers/wasm/src/devices/http_client.rs
+++ b/drivers/wasm/src/devices/http_client.rs
@@ -69,7 +69,7 @@ fn build_request<'a>(scheme: &str, request: HttpRequestParser<'a>) -> Option<Req
 
     let url = format!("{}://{}{}", scheme, host?, path.unwrap_or("/"));
 
-    Some(Request::new_with_str_and_init(&url, &options).ok()?)
+    Request::new_with_str_and_init(&url, &options).ok()
 }
 
 fn build_headers_response(response: &web_sys::Response, buffer: &mut [u8]) -> Result<usize> {
@@ -78,7 +78,7 @@ fn build_headers_response(response: &web_sys::Response, buffer: &mut [u8]) -> Re
     // Status code
     let status = response.status();
     builder
-        .add_status_code(status as u16)
+        .add_status_code(status)
         .ok_or(Error::InternalError)?;
 
     // Headers

--- a/drivers/wasm/src/devices/time.rs
+++ b/drivers/wasm/src/devices/time.rs
@@ -69,7 +69,7 @@ impl DirectBaseOperations for TimeDevice {
 
         buffer[..duration_bytes.len()].copy_from_slice(duration_bytes);
 
-        Ok(duration_bytes.len().into())
+        Ok(duration_bytes.len())
     }
 
     fn write(&self, _: &[u8], _: Size) -> Result<usize> {

--- a/examples/wasm/src/main.rs
+++ b/examples/wasm/src/main.rs
@@ -86,7 +86,7 @@ async fn main() {
     let partition = Box::leak(Box::new(partition));
 
     // Print MBR information
-    let mbr = Mbr::read_from_device(&*drive).unwrap();
+    let mbr = Mbr::read_from_device(drive).unwrap();
     log::information!("MBR Information: {mbr}");
 
     // Mount the file system

--- a/executables/file_manager/src/file_manager.rs
+++ b/executables/file_manager/src/file_manager.rs
@@ -6,20 +6,20 @@ pub(crate) use alloc::{
     vec::Vec,
 };
 use core::ptr::null_mut;
-use xila::internationalization::translate;
 use xila::log;
 use xila::task;
 use xila::virtual_file_system::{Directory, get_instance};
 use xila::{
     file_system::{Kind, Path, PathOwned},
     graphics::{
-        self, EventKind, Window, lvgl,
+        self, EventKind, lvgl,
         palette::{self, Hue},
     },
 };
+use xila::{graphics::OwnedWindow, internationalization::translate};
 
 pub struct FileManager {
-    window: Window,
+    window: OwnedWindow,
     toolbar: *mut lvgl::lv_obj_t,
     up_button: *mut lvgl::lv_obj_t,
     home_button: *mut lvgl::lv_obj_t,
@@ -63,15 +63,15 @@ impl FileManager {
             // Set up window layout for flex
             unsafe {
                 lvgl::lv_obj_set_layout(
-                    manager.window.get_object(),
+                    manager.window.as_object_mutable(),
                     lvgl::lv_layout_t_LV_LAYOUT_FLEX,
                 );
                 lvgl::lv_obj_set_flex_flow(
-                    manager.window.get_object(),
+                    manager.window.as_object_mutable(),
                     lvgl::lv_flex_flow_t_LV_FLEX_FLOW_COLUMN,
                 );
                 lvgl::lv_obj_set_style_pad_all(
-                    manager.window.get_object(),
+                    manager.window.as_object_mutable(),
                     0,
                     lvgl::LV_STATE_DEFAULT,
                 );
@@ -103,10 +103,10 @@ impl FileManager {
 
     pub async fn handle_event(&mut self, event: graphics::Event) -> Result<()> {
         match event.code {
-            EventKind::Delete | EventKind::CloseRequested => {
-                if event.target == self.window.get_object() {
-                    self.running = false;
-                }
+            EventKind::Delete | EventKind::CloseRequested
+                if event.target == self.window.as_object_mutable() =>
+            {
+                self.running = false;
             }
             EventKind::Clicked => {
                 let target = event.target;
@@ -133,7 +133,7 @@ impl FileManager {
 
     async fn create_toolbar(&mut self) -> Result<()> {
         unsafe {
-            self.toolbar = lvgl::lv_obj_create(self.window.get_object());
+            self.toolbar = lvgl::lv_obj_create(self.window.as_object_mutable());
             if self.toolbar.is_null() {
                 return Err(Error::FailedToCreateObject);
             }
@@ -223,7 +223,7 @@ impl FileManager {
 
     async fn create_file_list(&mut self) -> Result<()> {
         unsafe {
-            self.file_list = lvgl::lv_list_create(self.window.get_object());
+            self.file_list = lvgl::lv_list_create(self.window.as_object_mutable());
             if self.file_list.is_null() {
                 return Err(Error::FailedToCreateObject);
             }

--- a/executables/settings/src/settings.rs
+++ b/executables/settings/src/settings.rs
@@ -1,7 +1,8 @@
 use alloc::string::String;
 use xila::file_system::Kind;
+use xila::graphics::OwnedWindow;
 use xila::graphics::{
-    self, EventKind, Window, lvgl,
+    self, EventKind, lvgl,
     palette::{self, Hue},
 };
 
@@ -9,7 +10,7 @@ use crate::error::Result;
 use crate::tabs::{AboutTab, GeneralTab, NetworkTab, PasswordTab, Tab};
 
 pub struct Settings {
-    window: Window,
+    window: OwnedWindow,
     tabs: [Tab; 4],
 }
 
@@ -30,7 +31,7 @@ impl Settings {
 
         // Create tabview
         let tabview = unsafe {
-            let tabview = lvgl::lv_tabview_create(window.get_object());
+            let tabview = lvgl::lv_tabview_create(window.as_object_mutable());
 
             if tabview.is_null() {
                 return Err(crate::error::Error::FailedToCreateUiElement);
@@ -60,7 +61,7 @@ impl Settings {
             while let Some(event) = self.window.pop_event() {
                 // Logique de filtrage spécifique à Settings
                 if (event.code == EventKind::Delete || event.code == EventKind::CloseRequested)
-                    && event.target == self.window.get_object()
+                    && event.target == self.window.as_object_mutable()
                 {
                     return false;
                 }

--- a/executables/shell/command_line/src/lib.rs
+++ b/executables/shell/command_line/src/lib.rs
@@ -125,14 +125,12 @@ impl Shell {
             None => return Ok(()),
         };
 
-        let result = match next_positional {
-            command => match resolve_user_command(command) {
-                Some(user_command) => {
-                    let mut context = ShellCommandContext::new(self);
-                    dispatch_user_command(user_command, &mut context, &mut options, paths).await
-                }
-                None => self.execute(input, paths).await,
-            },
+        let result = match resolve_user_command(next_positional) {
+            Some(user_command) => {
+                let mut context = ShellCommandContext::new(self);
+                dispatch_user_command(user_command, &mut context, &mut options, paths).await
+            }
+            None => self.execute(input, paths).await,
         };
 
         if let Err(error) = result {

--- a/executables/shell/graphical/src/desk.rs
+++ b/executables/shell/graphical/src/desk.rs
@@ -12,7 +12,7 @@ use alloc::{
     vec,
     vec::Vec,
 };
-use xila::graphics::{self, Color, EventKind, Logo, Point, Window, lvgl};
+use xila::graphics::{self, Color, EventKind, Logo, OwnedWindow, Point, lvgl};
 use xila::log::{self, error, warning};
 use xila::task;
 use xila::virtual_file_system::{self, Directory};
@@ -26,7 +26,7 @@ use xila::{file_system::Kind, graphics::symbol};
 pub const WINDOWS_PARENT_CHILD_CHANGED: graphics::EventKind = graphics::EventKind::Custom2;
 
 pub struct Desk {
-    window: Window,
+    window: OwnedWindow,
     tile_view: *mut lvgl::lv_obj_t,
     drawer_tile: *mut lvgl::lv_obj_t,
     desk_tile: *mut lvgl::lv_obj_t,
@@ -72,8 +72,8 @@ impl Desk {
 
     pub const HOME_EVENT: EventKind = EventKind::Custom1;
 
-    pub fn get_window_object(&self) -> *mut lvgl::lv_obj_t {
-        self.window.get_object()
+    pub fn get_window_object(&mut self) -> *mut lvgl::lv_obj_t {
+        self.window.as_object_mutable()
     }
 
     pub fn is_hidden(&self) -> bool {
@@ -89,20 +89,20 @@ impl Desk {
             window.set_icon("De", Color::BLACK);
 
             unsafe {
-                lvgl::lv_obj_set_style_pad_all(window.get_object(), 0, lvgl::LV_STATE_DEFAULT);
+                lvgl::lv_obj_set_style_pad_all(window.as_mut(), 0, lvgl::LV_STATE_DEFAULT);
 
                 lvgl::lv_obj_add_event_cb(
                     windows_parent,
                     Some(event_handler),
                     EventKind::All as u32,
-                    window.get_object() as *mut core::ffi::c_void,
+                    window.as_object_mutable() as *mut _ as *mut _,
                 );
             }
 
             // - Create the logo
             unsafe {
                 // Create the logo in the background of the window
-                let logo = Logo::new(window.get_object(), 4, Color::BLACK)?;
+                let logo = Logo::new(window.as_mut(), 4, Color::BLACK)?;
                 let logo_inner_object = logo.get_inner_object();
                 forget(logo); // Prevent the logo from being dropped
 
@@ -133,7 +133,7 @@ impl Desk {
 
             // - Create a tile view
             let tile_view = unsafe {
-                let tile_view = lvgl::lv_tileview_create(window.get_object());
+                let tile_view = lvgl::lv_tileview_create(window.as_mut());
 
                 if tile_view.is_null() {
                     return Err(Error::FailedToCreateObject);
@@ -353,7 +353,7 @@ impl Desk {
         unsafe {
             self.close_dock_menu();
 
-            let menu = lvgl::lv_list_create(self.window.get_object());
+            let menu = lvgl::lv_list_create(self.window.as_object_mutable());
 
             if menu.is_null() {
                 return Err(Error::FailedToCreateObject);
@@ -560,17 +560,13 @@ impl Desk {
             Self::HOME_EVENT => unsafe {
                 lvgl::lv_tileview_set_tile_by_index(self.tile_view, 0, 0, true);
             },
-            EventKind::ValueChanged => {
-                if event.target == self.tile_view {
-                    unsafe {
-                        if lvgl::lv_tileview_get_tile_active(self.tile_view) == self.desk_tile {
-                            lvgl::lv_obj_clean(self.drawer_tile);
-                        } else if lvgl::lv_obj_get_child_count(self.drawer_tile) == 0 {
-                            let _ = self.create_drawer_interface(self.drawer_tile).await;
-                        }
-                    }
+            EventKind::ValueChanged if event.target == self.tile_view => unsafe {
+                if lvgl::lv_tileview_get_tile_active(self.tile_view) == self.desk_tile {
+                    lvgl::lv_obj_clean(self.drawer_tile);
+                } else if lvgl::lv_obj_get_child_count(self.drawer_tile) == 0 {
+                    let _ = self.create_drawer_interface(self.drawer_tile).await;
                 }
-            }
+            },
             EventKind::Clicked => {
                 if self
                     .dock_menu_maximize_button
@@ -668,43 +664,38 @@ impl Desk {
                     }
                 }
             }
-            EventKind::LongPressed => {
+            EventKind::LongPressed
                 if unsafe { lvgl::lv_obj_get_parent(event.target) == self.dock }
-                    && event.target != self.main_button
-                {
-                    let window_identifier =
-                        unsafe { lvgl::lv_obj_get_user_data(event.target) as usize };
+                    && event.target != self.main_button =>
+            {
+                let window_identifier =
+                    unsafe { lvgl::lv_obj_get_user_data(event.target) as usize };
 
-                    unsafe {
-                        self.open_dock_menu(event.target, window_identifier)?;
-                    }
+                unsafe {
+                    self.open_dock_menu(event.target, window_identifier)?;
                 }
             }
-            EventKind::Pressed => {
-                if event.target == self.main_button
-                    || unsafe { lvgl::lv_obj_get_parent(event.target) == self.main_button }
-                {
-                    unsafe {
-                        lvgl::lv_obj_add_state(self.main_button, lvgl::LV_STATE_PRESSED as u16);
-                        for i in 0..4 {
-                            let part = lvgl::lv_obj_get_child(self.main_button, i);
+            EventKind::Pressed
+                if (event.target == self.main_button
+                    || unsafe { lvgl::lv_obj_get_parent(event.target) == self.main_button }) =>
+            unsafe {
+                lvgl::lv_obj_add_state(self.main_button, lvgl::LV_STATE_PRESSED as u16);
+                for i in 0..4 {
+                    let part = lvgl::lv_obj_get_child(self.main_button, i);
 
-                            lvgl::lv_obj_add_state(part, lvgl::LV_STATE_PRESSED as u16);
-                        }
-                    }
+                    lvgl::lv_obj_add_state(part, lvgl::LV_STATE_PRESSED as u16);
                 }
-            }
-            EventKind::Released => {
-                if event.target == self.main_button
-                    || unsafe { lvgl::lv_obj_get_parent(event.target) == self.main_button }
-                {
-                    unsafe {
-                        self.clear_main_button_pressed_state();
-                    }
+            },
+            EventKind::Released
+                if (event.target == self.main_button
+                    || unsafe { lvgl::lv_obj_get_parent(event.target) == self.main_button }) =>
+            {
+                unsafe {
+                    self.clear_main_button_pressed_state();
+                }
 
-                    unsafe {
-                        lvgl::lv_tileview_set_tile_by_index(self.tile_view, 0, 1, true);
-                    }
+                unsafe {
+                    lvgl::lv_tileview_set_tile_by_index(self.tile_view, 0, 1, true);
                 }
             }
             EventKind::PressLost => unsafe {

--- a/executables/shell/graphical/src/layout.rs
+++ b/executables/shell/graphical/src/layout.rs
@@ -88,21 +88,17 @@ pub unsafe extern "C" fn screen_event_handler(event: *mut lvgl::lv_event_t) {
         }
 
         match code {
-            EventKind::Focused => {
-                if lvgl::lv_obj_has_class(target, &lvgl::lv_textarea_class) {
-                    lvgl::lv_keyboard_set_textarea(keyboard, target);
-                    lvgl::lv_obj_remove_flag(keyboard, lvgl::lv_obj_flag_t_LV_OBJ_FLAG_HIDDEN);
-                    lvgl::lv_obj_move_foreground(keyboard);
+            EventKind::Focused if lvgl::lv_obj_has_class(target, &lvgl::lv_textarea_class) => {
+                lvgl::lv_keyboard_set_textarea(keyboard, target);
+                lvgl::lv_obj_remove_flag(keyboard, lvgl::lv_obj_flag_t_LV_OBJ_FLAG_HIDDEN);
+                lvgl::lv_obj_move_foreground(keyboard);
 
-                    let width = lvgl::lv_obj_get_width(keyboard);
-                    lvgl::lv_obj_set_height(keyboard, (width as f64 / KEYBOARD_SIZE_RATIO) as i32);
-                }
+                let width = lvgl::lv_obj_get_width(keyboard);
+                lvgl::lv_obj_set_height(keyboard, (width as f64 / KEYBOARD_SIZE_RATIO) as i32);
             }
-            EventKind::Defocused => {
-                if lvgl::lv_obj_has_class(target, &lvgl::lv_textarea_class) {
-                    lvgl::lv_keyboard_set_textarea(keyboard, null_mut());
-                    lvgl::lv_obj_add_flag(keyboard, lvgl::lv_obj_flag_t_LV_OBJ_FLAG_HIDDEN);
-                }
+            EventKind::Defocused if lvgl::lv_obj_has_class(target, &lvgl::lv_textarea_class) => {
+                lvgl::lv_keyboard_set_textarea(keyboard, null_mut());
+                lvgl::lv_obj_add_flag(keyboard, lvgl::lv_obj_flag_t_LV_OBJ_FLAG_HIDDEN);
             }
             _ => {}
         }

--- a/executables/shell/graphical/src/login.rs
+++ b/executables/shell/graphical/src/login.rs
@@ -1,8 +1,7 @@
-pub(crate) use core::ffi::CStr;
-
 use alloc::string::ToString;
+pub(crate) use core::ffi::CStr;
 use xila::authentication;
-use xila::graphics::{self, EventKind, Window, lvgl};
+use xila::graphics::{self, EventKind, OwnedWindow, lvgl};
 use xila::internationalization::translate;
 use xila::task;
 use xila::users::UserIdentifier;
@@ -11,7 +10,7 @@ use xila::virtual_file_system;
 use crate::error::{Error, Result};
 
 pub struct Login {
-    window: Window,
+    window: OwnedWindow,
     user_name_text_area: *mut lvgl::lv_obj_t,
     password_text_area: *mut lvgl::lv_obj_t,
     button: *mut lvgl::lv_obj_t,
@@ -24,12 +23,12 @@ impl Login {
         // - Lock the graphics
         graphics::lock!({
             // - Create a window
-            let window = graphics::get_instance().create_window().await?;
+            let mut window = graphics::get_instance().create_window().await?;
 
             unsafe {
-                lvgl::lv_obj_set_flex_flow(window.get_object(), lvgl::LV_FLEX_COLUMN);
+                lvgl::lv_obj_set_flex_flow(window.as_object_mutable(), lvgl::LV_FLEX_COLUMN);
                 lvgl::lv_obj_set_flex_align(
-                    window.get_object(),
+                    window.as_object_mutable(),
                     lvgl::lv_flex_align_t_LV_FLEX_ALIGN_CENTER,
                     lvgl::lv_flex_align_t_LV_FLEX_ALIGN_CENTER,
                     lvgl::lv_flex_align_t_LV_FLEX_ALIGN_CENTER,
@@ -38,7 +37,7 @@ impl Login {
 
             let user_name_text_area = unsafe {
                 // - Create a text area for the user name
-                let user_name_text_area = lvgl::lv_textarea_create(window.get_object());
+                let user_name_text_area = lvgl::lv_textarea_create(window.as_object_mutable());
 
                 lvgl::lv_textarea_set_placeholder_text(
                     user_name_text_area,
@@ -51,7 +50,7 @@ impl Login {
 
             let password_text_area = unsafe {
                 // - Create a text area for the password
-                let password_text_area = lvgl::lv_textarea_create(window.get_object());
+                let password_text_area = lvgl::lv_textarea_create(window.as_mut());
 
                 lvgl::lv_textarea_set_placeholder_text(
                     password_text_area,
@@ -65,7 +64,7 @@ impl Login {
 
             let error_label = unsafe {
                 // - Create a label for the error
-                let error_label = lvgl::lv_label_create(window.get_object());
+                let error_label = lvgl::lv_label_create(window.as_mut());
 
                 lvgl::lv_label_set_text(error_label, c"".as_ptr());
 
@@ -74,7 +73,7 @@ impl Login {
 
             let button = unsafe {
                 // - Create a button
-                let button = lvgl::lv_button_create(window.get_object());
+                let button = lvgl::lv_button_create(window.as_mut());
 
                 let label = lvgl::lv_label_create(button);
 
@@ -151,7 +150,7 @@ impl Login {
 
     pub async fn event_handler(&mut self) {
         graphics::lock! {{
-            while let Some(event) = self.window.pop_event() {
+            while let Some(event) = self.window.pop_event()  {
             // If we are typing the user name or the password
             if event.code == EventKind::ValueChanged
                 && (event.target == self.user_name_text_area

--- a/executables/terminal/src/terminal.rs
+++ b/executables/terminal/src/terminal.rs
@@ -1,15 +1,16 @@
 use crate::error::{Error, Result};
 use alloc::{collections::vec_deque::VecDeque, string::String};
 use core::ffi::CStr;
+use xila::graphics::OwnedWindow;
 use xila::graphics::fonts::get_font_monospace_medium;
 use xila::graphics::{
-    self, Color, EventKind, Key, Window,
+    self, Color, EventKind, Key,
     lvgl::{self, lv_obj_t},
 };
 use xila::synchronization::{blocking_mutex::raw::CriticalSectionRawMutex, rwlock::RwLock};
 
 pub(crate) struct Inner {
-    window: Window,
+    window: OwnedWindow,
     buffer: String,
     display: *mut lvgl::lv_obj_t,
     input: *mut lvgl::lv_obj_t,
@@ -34,13 +35,13 @@ impl Terminal {
                 window.set_icon(">_", Color::BLACK);
 
                 lvgl::lv_obj_set_flex_flow(
-                    window.get_object(),
+                    window.as_object_mutable(),
                     lvgl::lv_flex_flow_t_LV_FLEX_FLOW_COLUMN,
                 );
             }
 
             let container = unsafe {
-                let container = lvgl::lv_obj_create(window.get_object());
+                let container = lvgl::lv_obj_create(window.as_object_mutable());
 
                 lvgl::lv_obj_set_width(container, lvgl::lv_pct(100));
                 lvgl::lv_obj_set_flex_grow(container, 1);
@@ -74,7 +75,7 @@ impl Terminal {
             };
 
             let input = unsafe {
-                let input = lvgl::lv_textarea_create(window.get_object());
+                let input = lvgl::lv_textarea_create(window.as_object_mutable());
 
                 if input.is_null() {
                     return Err(crate::error::Error::FailedToCreateObject);
@@ -191,10 +192,10 @@ impl Terminal {
 
             while let Some(event) = inner.window.pop_event() {
                 match event.code {
-                    EventKind::Delete | EventKind::CloseRequested => {
-                        if event.target == inner.window.get_object() {
-                            running = false;
-                        }
+                    EventKind::Delete | EventKind::CloseRequested
+                        if event.target == inner.window.as_object_mutable() =>
+                    {
+                        running = false;
                     }
                     EventKind::Key => {
                         if let Some(Key::Enter) = event.key {

--- a/executables/wasm/build/host.rs
+++ b/executables/wasm/build/host.rs
@@ -155,7 +155,7 @@ pub fn generate_code(
             };
 
             unsafe {
-                let result = match __function {
+                match __function {
                     #(
                         #functions_call
                     )*

--- a/executables/wasm/build/utilities/context.rs
+++ b/executables/wasm/build/utilities/context.rs
@@ -80,6 +80,7 @@ impl LvglContext {
             "lv_obj_null_on_delete",
             "lv_buttonmatrix_get_map",
             "lv_textarea_get_text",
+            "lv_obj_get_layer_type",
         ];
 
         let signature_ident_str = signature.ident.to_string();

--- a/executables/wasm/src/host/bindings/graphics/additionnal.rs
+++ b/executables/wasm/src/host/bindings/graphics/additionnal.rs
@@ -1,4 +1,4 @@
-use core::ffi::CStr;
+use core::{ffi::CStr, ptr::NonNull};
 
 use xila::{
     graphics::{self, Color, Window, lvgl},
@@ -16,9 +16,11 @@ pub unsafe fn object_delete(__translator: &mut Translator, object: WasmPointer) 
 }
 
 pub unsafe fn window_create() -> *mut lvgl::lv_obj_t {
-    task::block_on(graphics::get_instance().create_window())
-        .unwrap()
-        .into_raw()
+    let window = task::block_on(graphics::get_instance().create_window()).unwrap();
+
+    let window: NonNull<Window> = window.into();
+
+    window.as_ptr() as *mut lvgl::lv_obj_t
 }
 
 pub unsafe fn window_pop_event(
@@ -27,9 +29,12 @@ pub unsafe fn window_pop_event(
     code: *mut u32,
     target: *mut WasmPointer,
 ) {
-    let mut window = unsafe { graphics::Window::from_raw(window) };
+    let mut window = match unsafe { Window::from_raw(window) } {
+        Some(window) => window,
+        None => return,
+    };
 
-    if let Some(event) = window.pop_event() {
+    if let Some(event) = unsafe { window.as_mut().pop_event() } {
         unsafe {
             *code = event.code as u32;
 
@@ -38,48 +43,47 @@ pub unsafe fn window_pop_event(
                 .unwrap_or(0);
         }
     }
-
-    core::mem::forget(window);
 }
 
 pub unsafe fn window_get_event_code(window: *mut lvgl::lv_obj_t) -> u32 {
-    let window = unsafe { graphics::Window::from_raw(window) };
+    let mut window = match unsafe { Window::from_raw(window) } {
+        Some(window) => window,
+        None => return graphics::EventKind::All as u32,
+    };
 
-    let code = if let Some(event) = window.peek_event() {
+    if let Some(event) = unsafe { window.as_mut().peek_event() } {
         event.code as u32
     } else {
         graphics::EventKind::All as u32
-    };
-
-    core::mem::forget(window);
-
-    code
+    }
 }
 
 pub unsafe fn window_get_event_target(
     __translator: &mut Translator,
     window: *mut lvgl::lv_obj_t,
 ) -> WasmPointer {
-    let window = unsafe { graphics::Window::from_raw(window) };
+    let mut window = match unsafe { Window::from_raw(window) } {
+        Some(window) => window,
+        None => return 0,
+    };
 
-    let target = if let Some(event) = window.peek_event() {
+    let target = if let Some(event) = unsafe { window.as_mut().peek_event() } {
         event.target
     } else {
         log::warning!("No event available for the window");
         core::ptr::null_mut()
     };
 
-    core::mem::forget(window);
-
     unsafe { __translator.translate_to_guest(target, false).unwrap() }
 }
 
 pub unsafe fn window_next_event(window: *mut lvgl::lv_obj_t) {
-    let mut window = unsafe { Window::from_raw(window) };
+    let mut window = match unsafe { Window::from_raw(window) } {
+        Some(window) => window,
+        None => return,
+    };
 
-    window.pop_event();
-
-    core::mem::forget(window);
+    unsafe { window.as_mut().pop_event() };
 }
 
 pub unsafe fn window_set_icon(
@@ -87,14 +91,15 @@ pub unsafe fn window_set_icon(
     icon_string: *const core::ffi::c_char,
     icon_color: lvgl::lv_color_t,
 ) {
-    let mut window = unsafe { Window::from_raw(window) };
+    let mut window = match unsafe { Window::from_raw(window) } {
+        Some(window) => window,
+        None => return,
+    };
 
     let icon_string = unsafe { CStr::from_ptr(icon_string).to_str().unwrap() };
 
     let icon_color = Color::from_lvgl_color(icon_color);
-    window.set_icon(icon_string, icon_color);
-
-    core::mem::forget(window);
+    unsafe { window.as_mut().set_icon(icon_string, icon_color) };
 }
 
 pub unsafe fn percentage(value: i32) -> i32 {

--- a/executables/weather/src/format.rs
+++ b/executables/weather/src/format.rs
@@ -26,33 +26,21 @@ pub fn format_hourly_tab(hourly: Option<&HourlyWeather>) -> String {
         return String::from("No hourly data.");
     };
 
-    let times = h.time.as_ref().map(|v| v.as_slice()).unwrap_or(&[]);
-    let temps = h
-        .temperature_2m
-        .as_ref()
-        .map(|v| v.as_slice())
-        .unwrap_or(&[]);
-    let probs = h
-        .precipitation_probability
-        .as_ref()
-        .map(|v| v.as_slice())
-        .unwrap_or(&[]);
-    let winds = h
-        .wind_speed_10m
-        .as_ref()
-        .map(|v| v.as_slice())
-        .unwrap_or(&[]);
+    let times = h.time.as_deref().unwrap_or(&[]);
+    let temps = h.temperature_2m.as_deref().unwrap_or(&[]);
+    let probs = h.precipitation_probability.as_deref().unwrap_or(&[]);
+    let winds = h.wind_speed_10m.as_deref().unwrap_or(&[]);
 
     let mut out = String::from("Next 24h\n");
     let count = core::cmp::min(times.len(), 24);
 
-    for i in 0..count {
+    for (i, time) in times.iter().enumerate().take(count) {
         let temp = temps.get(i).copied().unwrap_or_default();
         let prob = probs.get(i).copied().unwrap_or_default();
         let wind = winds.get(i).copied().unwrap_or_default();
         out.push_str(&format!(
             "{} | {:.1} C | {}% rain | {:.1} km/h\n",
-            times[i], temp, prob, wind
+            time, temp, prob, wind
         ));
     }
 
@@ -64,31 +52,19 @@ pub fn format_daily_tab(daily: Option<&DailyWeather>) -> String {
         return String::from("No daily data.");
     };
 
-    let times = d.time.as_ref().map(|v| v.as_slice()).unwrap_or(&[]);
-    let maxs = d
-        .temperature_2m_max
-        .as_ref()
-        .map(|v| v.as_slice())
-        .unwrap_or(&[]);
-    let mins = d
-        .temperature_2m_min
-        .as_ref()
-        .map(|v| v.as_slice())
-        .unwrap_or(&[]);
-    let weather = d.weather_code.as_ref().map(|v| v.as_slice()).unwrap_or(&[]);
-    let precip = d
-        .precipitation_probability_max
-        .as_ref()
-        .map(|v| v.as_slice())
-        .unwrap_or(&[]);
-    let sunrise = d.sunrise.as_ref().map(|v| v.as_slice()).unwrap_or(&[]);
-    let sunset = d.sunset.as_ref().map(|v| v.as_slice()).unwrap_or(&[]);
+    let times = d.time.as_deref().unwrap_or(&[]);
+    let maxs = d.temperature_2m_max.as_deref().unwrap_or(&[]);
+    let mins = d.temperature_2m_min.as_deref().unwrap_or(&[]);
+    let weather = d.weather_code.as_deref().unwrap_or(&[]);
+    let precip = d.precipitation_probability_max.as_deref().unwrap_or(&[]);
+    let sunrise = d.sunrise.as_deref().unwrap_or(&[]);
+    let sunset = d.sunset.as_deref().unwrap_or(&[]);
 
     let mut out = String::from("Next days\n");
-    for i in 0..times.len().min(10) {
+    for (i, time) in times.iter().enumerate().take(10) {
         out.push_str(&format!(
             "{} | min {:.1} / max {:.1} C | code {} | rain {}%\n  sunrise {} sunset {}\n",
-            times[i],
+            time,
             mins.get(i).copied().unwrap_or_default(),
             maxs.get(i).copied().unwrap_or_default(),
             weather.get(i).copied().unwrap_or_default(),

--- a/executables/weather/src/net.rs
+++ b/executables/weather/src/net.rs
@@ -8,8 +8,6 @@ use std::fs::OpenOptions;
 #[cfg(target_arch = "wasm32")]
 use std::io::{ErrorKind, Read, Write};
 #[cfg(target_arch = "wasm32")]
-use std::println;
-#[cfg(target_arch = "wasm32")]
 use std::thread::{sleep, yield_now};
 
 #[cfg(target_arch = "wasm32")]
@@ -40,7 +38,7 @@ fn read_with_retry(
                     sleep(std::time::Duration::from_millis(1));
                 }
             }
-            Err(error) => {
+            Err(_error) => {
                 return Err(String::from(error_label));
             }
         }
@@ -167,7 +165,7 @@ pub fn https_get(url: &str) -> Result<Vec<u8>, String> {
         .read(true)
         .write(true)
         .open("/devices/https_client")
-        .map_err(|e| String::from("failed to open https device"))?;
+        .map_err(|_e| String::from("failed to open https device"))?;
 
     file.write_all(&request_buffer[..request_length])
         .map_err(|_| String::from("failed to write request"))?;
@@ -197,24 +195,24 @@ pub fn https_get(url: &str) -> Result<Vec<u8>, String> {
     let mut chunk = [0u8; 4096];
     let mut retry_count = 0usize;
     loop {
-        if let Some(expected_length) = expected_body_length {
-            if body.len() >= expected_length {
-                break;
-            }
+        if let Some(expected_length) = expected_body_length
+            && body.len() >= expected_length
+        {
+            break;
         }
 
         let count = read_with_retry(&mut file, &mut chunk, "failed to read body")?;
         if count == 0 {
-            if let Some(expected_length) = expected_body_length {
-                if body.len() < expected_length {
-                    retry_count += 1;
-                    if retry_count >= HTTPS_READ_MAX_RETRIES {
-                        return Err(String::from("timed out waiting for https response body"));
-                    }
-
-                    yield_now();
-                    continue;
+            if let Some(expected_length) = expected_body_length
+                && body.len() < expected_length
+            {
+                retry_count += 1;
+                if retry_count >= HTTPS_READ_MAX_RETRIES {
+                    return Err(String::from("timed out waiting for https response body"));
                 }
+
+                yield_now();
+                continue;
             }
 
             break;
@@ -225,9 +223,7 @@ pub fn https_get(url: &str) -> Result<Vec<u8>, String> {
 
     // Decode chunked transfer encoding if present
     let final_body = if has_chunked_encoding(&headers_buffer[..headers_len]) {
-        let decoded = decode_chunked_body(&body)?;
-
-        decoded
+        decode_chunked_body(&body)?
     } else {
         body
     };

--- a/modules/graphics/include/lv_conf.h
+++ b/modules/graphics/include/lv_conf.h
@@ -485,7 +485,7 @@
 #define LV_USE_MATRIX           0
 
 /** Include `lvgl_private.h` in `lvgl.h` to access internal data and functions by default */
-#define LV_USE_PRIVATE_API		0
+#define LV_USE_PRIVATE_API		1
 
 /*==================
  *   FONT USAGE

--- a/modules/graphics/src/manager.rs
+++ b/modules/graphics/src/manager.rs
@@ -9,17 +9,17 @@ use synchronization::mutex::{Mutex, MutexGuard};
 use synchronization::{once_lock::OnceLock, rwlock::RwLock};
 use task::block_on;
 
-use core::{future::Future, mem::forget};
+use core::future::Future;
 
 use core::time::Duration;
 
 use super::lvgl;
 
-use crate::Display;
 use crate::Input;
 use crate::InputKind;
 use crate::window::Window;
 use crate::{Color, theme};
+use crate::{Display, OwnedWindow};
 use crate::{Error, Result};
 
 static MANAGER_INSTANCE: OnceLock<Manager> = OnceLock::new();
@@ -163,12 +163,12 @@ impl Manager {
         Ok(())
     }
 
-    pub async fn create_window(&self) -> Result<Window> {
+    pub async fn create_window(&self) -> Result<OwnedWindow> {
         let parent_object = self.inner.write().await.window_parent;
 
         let window = unsafe { Window::new(parent_object)? };
 
-        Ok(window)
+        Ok(OwnedWindow::new(window))
     }
 
     pub async fn add_input_device(
@@ -209,14 +209,12 @@ impl Manager {
         let window = unsafe {
             let child = lvgl::lv_obj_get_child(window_parent, index as i32);
 
-            Window::from_raw(child)
+            Window::from_raw(child).ok_or(Error::InvalidWindowIdentifier)?
         };
 
-        let icon = window.get_icon();
+        let icon = unsafe { window.as_ref().get_icon() };
 
         let icon = (icon.0.to_string(), icon.1);
-
-        forget(window);
 
         Ok(icon)
     }

--- a/modules/graphics/src/window.rs
+++ b/modules/graphics/src/window.rs
@@ -1,91 +1,144 @@
 use super::lvgl;
-use crate::{Color, Error, EventKind, Result, event::Event};
-use alloc::boxed::Box;
+use crate::{Color, Error, EventKind, Key, Result, event::Event, synchronous_lock};
 use alloc::collections::VecDeque;
-use core::{future::poll_fn, mem::forget, str, task::Poll};
-use synchronization::waitqueue::AtomicWaker;
+use core::{
+    future::poll_fn,
+    mem::{ManuallyDrop, forget},
+    ops::{Deref, DerefMut},
+    ptr::{self, NonNull},
+    str,
+    task::Poll,
+};
+use synchronization::{once_lock::OnceLock, waitqueue::AtomicWaker};
 
-struct UserData {
-    pub queue: VecDeque<Event>,
-    pub icon_text: [u8; 2],
-    pub icon_color: Color,
-    pub waker_registration: AtomicWaker,
+const WINDOW_QUEUE_DEFAULT_CAPACITY: usize = 10;
+
+#[repr(transparent)]
+pub struct ClassWrapper(lvgl::lv_obj_class_t);
+
+unsafe impl Send for ClassWrapper {}
+unsafe impl Sync for ClassWrapper {}
+
+static WINDOW_CLASS: OnceLock<ClassWrapper> = OnceLock::new();
+
+pub fn get_window_class() -> &'static lvgl::lv_obj_class_t {
+    let class_ref = WINDOW_CLASS.get_or_init(|| {
+        let mut cls = lvgl::lv_obj_class_t {
+            base_class: unsafe { &lvgl::lv_obj_class },
+            constructor_cb: Some(window_constructor),
+            destructor_cb: Some(window_destructor),
+            event_cb: Some(window_event_callback),
+            width_def: unsafe { lvgl::lv_pct(100) },
+            height_def: unsafe { lvgl::lv_pct(100) },
+            name: c"window".as_ptr(),
+            ..Default::default()
+        };
+
+        cls.set_instance_size(size_of::<Window>() as _);
+        cls.set_group_def(lvgl::lv_obj_class_group_def_t_LV_OBJ_CLASS_GROUP_DEF_INHERIT as _);
+        cls.set_theme_inheritable(
+            lvgl::lv_obj_class_theme_inheritable_t_LV_OBJ_CLASS_THEME_INHERITABLE_TRUE as _,
+        );
+        cls.set_editable(lvgl::lv_obj_class_editable_t_LV_OBJ_CLASS_EDITABLE_INHERIT as _);
+
+        ClassWrapper(cls)
+    });
+
+    &class_ref.0
 }
 
-#[derive(Clone)]
+#[repr(C)]
 pub struct Window {
-    window: *mut lvgl::lv_obj_t,
+    object: lvgl::lv_obj_t,
+    event_queue: VecDeque<Event>,
+    icon_text: [u8; 2],
+    icon_color: Color,
+    waker_registration: AtomicWaker,
 }
 
-impl Drop for Window {
-    fn drop(&mut self) {
-        if !self.is_valid() {
-            return;
-        }
+unsafe extern "C" fn window_constructor(
+    _class_p: *const lvgl::lv_obj_class_t,
+    object: *mut lvgl::lv_obj_t,
+) {
+    unsafe {
+        let window = object as *mut Window;
 
-        unsafe {
-            let user_data = lvgl::lv_obj_get_user_data(self.window) as *mut UserData;
+        ptr::write(
+            &mut (*window).event_queue,
+            VecDeque::with_capacity(WINDOW_QUEUE_DEFAULT_CAPACITY),
+        );
+        ptr::write(&mut (*window).icon_text, [b'W', b'i']);
+        ptr::write(&mut (*window).icon_color, Color::BLACK);
+        ptr::write(&mut (*window).waker_registration, AtomicWaker::new());
 
-            let _user_data = Box::from_raw(user_data);
-
-            lvgl::lv_obj_delete(self.window);
-        }
+        lvgl::lv_obj_add_flag(
+            &mut (*window).object,
+            lvgl::lv_obj_flag_t_LV_OBJ_FLAG_EVENT_BUBBLE,
+        );
+        lvgl::lv_obj_set_style_border_width(&mut (*window).object, 0, lvgl::LV_STATE_DEFAULT);
+        lvgl::lv_obj_set_style_radius(&mut (*window).object, 0, lvgl::LV_STATE_DEFAULT);
     }
 }
 
-unsafe extern "C" fn event_callback(event: *mut lvgl::lv_event_t) {
+unsafe extern "C" fn window_destructor(
+    _class_p: *const lvgl::lv_obj_class_t,
+    obj: *mut lvgl::lv_obj_t,
+) {
     unsafe {
+        let window = obj as *mut Window;
+        // Appelle explicitement Drop sur l'ensemble des champs Rust de Window
+        core::ptr::drop_in_place(window);
+    }
+}
+
+unsafe extern "C" fn window_event_callback(
+    _class_p: *const lvgl::lv_obj_class_t,
+    event: *mut lvgl::lv_event_t,
+) {
+    unsafe {
+        let res = lvgl::lv_obj_event_base(get_window_class(), event);
+
+        if res != lvgl::lv_result_t_LV_RESULT_OK {
+            return; // Not our event, ignore it
+        }
+
         let code = lvgl::lv_event_get_code(event);
 
-        let user_data = lvgl::lv_event_get_user_data(event) as *mut UserData;
-
+        let window = lvgl::lv_event_get_current_target(event) as *mut Window;
         let target = lvgl::lv_event_get_target(event) as *mut lvgl::lv_obj_t;
 
-        match code {
+        let (code, key) = match code {
             lvgl::lv_event_code_t_LV_EVENT_CHILD_CREATED => {
                 lvgl::lv_obj_add_flag(target, lvgl::lv_obj_flag_t_LV_OBJ_FLAG_EVENT_BUBBLE);
-
-                (*user_data)
-                    .queue
-                    .push_back(Event::new(EventKind::ChildCreated, target, None));
-                (*user_data).waker_registration.wake();
+                (code, None)
+            }
+            lvgl::lv_event_code_t_LV_EVENT_KEY => {
+                let key = lvgl::lv_indev_get_key(lvgl::lv_indev_active());
+                let key = Key::from(key);
+                (code, Some(key))
             }
             lvgl::lv_event_code_t_LV_EVENT_DRAW_MAIN
             | lvgl::lv_event_code_t_LV_EVENT_DRAW_MAIN_BEGIN
             | lvgl::lv_event_code_t_LV_EVENT_DRAW_MAIN_END
             | lvgl::lv_event_code_t_LV_EVENT_DRAW_POST
             | lvgl::lv_event_code_t_LV_EVENT_DRAW_POST_BEGIN
-            | lvgl::lv_event_code_t_LV_EVENT_DRAW_POST_END
             | lvgl::lv_event_code_t_LV_EVENT_GET_SELF_SIZE
             | lvgl::lv_event_code_t_LV_EVENT_COVER_CHECK
             | lvgl::lv_event_code_t_LV_EVENT_LAYOUT_CHANGED => {
+                return;
                 // Ignore draw events
             }
-            lvgl::lv_event_code_t_LV_EVENT_KEY => {
-                let key = lvgl::lv_indev_get_key(lvgl::lv_indev_active());
+            _ => (code, None),
+        };
 
-                (*user_data)
-                    .queue
-                    .push_back(Event::new(EventKind::Key, target, Some(key.into())));
-                (*user_data).waker_registration.wake();
-            }
-            _ => {
-                (*user_data).queue.push_back(Event::new(
-                    EventKind::from_lvgl_code(code),
-                    target,
-                    None,
-                ));
-                (*user_data).waker_registration.wake();
-            }
-        }
+        (*window)
+            .event_queue
+            .push_back(Event::new(EventKind::from_lvgl_code(code), target, key));
+        (*window).waker_registration.wake();
     }
 }
 
 impl Window {
-    fn is_valid(&self) -> bool {
-        unsafe { lvgl::lv_obj_is_valid(self.window) }
-    }
-
     /// Create a new window.
     ///
     /// # Arguments
@@ -100,120 +153,67 @@ impl Window {
     ///
     /// This function is unsafe because it may dereference raw pointers (e.g. `Parent_object`).
     ///
-    pub unsafe fn new(parent_object: *mut lvgl::lv_obj_t) -> Result<Self> {
-        let window = unsafe { lvgl::lv_obj_create(parent_object) };
-
-        if window.is_null() {
-            return Err(Error::FailedToCreateObject);
-        }
-
-        let user_data = UserData {
-            queue: VecDeque::with_capacity(10),
-            icon_text: [b'I', b'c'],
-            icon_color: Color::BLACK,
-            waker_registration: AtomicWaker::new(),
-        };
-
-        let mut user_data = Box::new(user_data);
+    pub unsafe fn new(parent: *mut lvgl::lv_obj_t) -> Result<NonNull<Self>> {
+        let obj = unsafe { lvgl::lv_obj_class_create_obj(get_window_class(), parent) };
 
         unsafe {
-            // Set the event callback for the window.
-            lvgl::lv_obj_add_event_cb(
-                window,
-                Some(event_callback),
-                lvgl::lv_event_code_t_LV_EVENT_ALL,
-                &mut user_data.queue as *mut _ as *mut core::ffi::c_void,
-            );
-            lvgl::lv_obj_add_flag(window, lvgl::lv_obj_flag_t_LV_OBJ_FLAG_EVENT_BUBBLE);
-            lvgl::lv_obj_set_user_data(window, Box::into_raw(user_data) as *mut core::ffi::c_void);
-            // Set the size of the window to 100% of the parent object.
-            lvgl::lv_obj_set_size(window, lvgl::lv_pct(100), lvgl::lv_pct(100));
-            lvgl::lv_obj_set_style_border_width(window, 0, lvgl::LV_STATE_DEFAULT);
-            lvgl::lv_obj_set_style_radius(window, 0, lvgl::LV_STATE_DEFAULT);
+            lvgl::lv_obj_class_init_obj(obj);
         }
 
-        Ok(Self { window })
+        match NonNull::new(obj as *mut Self) {
+            Some(window) => Ok(window),
+            None => Err(Error::FailedToCreateObject),
+        }
     }
 
     pub fn get_identifier(&self) -> usize {
-        self.window as usize
+        self as *const Self as usize
     }
 
     pub fn peek_event(&self) -> Option<Event> {
-        if !self.is_valid() {
-            return None;
-        }
-
-        let user_data = unsafe { lvgl::lv_obj_get_user_data(self.window) as *mut UserData };
-
-        let user_data = unsafe { Box::from_raw(user_data) };
-
-        let event = user_data.queue.front().cloned();
-
-        forget(user_data);
-
-        event
+        self.event_queue.front().cloned()
     }
 
     pub fn pop_event(&mut self) -> Option<Event> {
-        if !self.is_valid() {
-            return None;
-        }
-
-        let user_data = unsafe { lvgl::lv_obj_get_user_data(self.window) as *mut UserData };
-
-        let mut user_data = unsafe { Box::from_raw(user_data) };
-
-        let event = user_data.queue.pop_front();
-
-        forget(user_data);
-
-        event
+        self.event_queue.pop_front()
     }
 
-    pub fn get_object(&self) -> *mut lvgl::lv_obj_t {
-        self.window
+    pub fn as_object(&self) -> &lvgl::lv_obj_t {
+        &self.object
+    }
+
+    pub fn as_object_mutable(&mut self) -> &mut lvgl::lv_obj_t {
+        &mut self.object
     }
 
     pub fn get_icon(&self) -> (&str, Color) {
-        let user_data = unsafe {
-            let user_data = lvgl::lv_obj_get_user_data(self.window) as *mut UserData;
+        let icon_string = str::from_utf8(&self.icon_text)
+            .unwrap_or("??")
+            .trim_matches(char::from(0));
 
-            &*user_data
-        };
-
-        unsafe {
-            (
-                str::from_utf8_unchecked(&user_data.icon_text),
-                user_data.icon_color,
-            )
-        }
+        (icon_string, self.icon_color)
     }
 
     pub fn set_icon(&mut self, icon_string: &str, icon_color: Color) {
-        let user_data = unsafe { lvgl::lv_obj_get_user_data(self.window) as *mut UserData };
-
-        let user_data = unsafe { &mut *user_data };
-
         let mut iterator = icon_string.chars();
 
         if let Some(character) = iterator.next() {
-            user_data.icon_text[0] = character as u8;
+            self.icon_text[0] = character as u8;
         }
 
         if let Some(character) = iterator.next() {
-            user_data.icon_text[1] = character as u8;
+            self.icon_text[1] = character as u8;
         }
 
-        user_data.icon_color = icon_color;
+        self.icon_color = icon_color;
+    }
+
+    pub fn wake_up(&mut self) {
+        self.waker_registration.wake();
     }
 
     pub fn register_waker(&mut self, waker: &core::task::Waker) {
-        let user_data = unsafe { lvgl::lv_obj_get_user_data(self.window) as *mut UserData };
-
-        let user_data = unsafe { &mut *user_data };
-
-        user_data.waker_registration.register(waker);
+        self.waker_registration.register(waker);
     }
 
     /// Convert a raw pointer to a window object.
@@ -226,8 +226,18 @@ impl Window {
     ///
     /// This function is unsafe because it may dereference raw pointers (e.g. `Window`).
     ///
-    pub unsafe fn from_raw(window: *mut lvgl::lv_obj_t) -> Self {
-        Self { window }
+    pub unsafe fn from_raw(window: *mut lvgl::lv_obj_t) -> Option<NonNull<Self>> {
+        if !unsafe { lvgl::lv_obj_is_valid(window) } {
+            return None;
+        }
+
+        let class = unsafe { lvgl::lv_obj_get_class(window) };
+
+        if class != get_window_class() {
+            return None;
+        }
+
+        NonNull::new(window as *mut Self)
     }
 
     pub fn yield_now(&mut self) -> impl core::future::Future<Output = ()> + '_ {
@@ -243,11 +253,87 @@ impl Window {
         })
     }
 
-    pub fn into_raw(self) -> *mut lvgl::lv_obj_t {
-        let window = self.window;
+    pub fn delete(&mut self) {
+        unsafe {
+            lvgl::lv_obj_delete(&mut self.object);
+        }
+    }
+}
 
-        forget(self);
+impl AsRef<lvgl::lv_obj_t> for Window {
+    #[inline]
+    fn as_ref(&self) -> &lvgl::lv_obj_t {
+        &self.object
+    }
+}
 
-        window
+impl AsMut<lvgl::lv_obj_t> for Window {
+    #[inline]
+    fn as_mut(&mut self) -> &mut lvgl::lv_obj_t {
+        &mut self.object
+    }
+}
+
+impl Deref for Window {
+    type Target = lvgl::lv_obj_t;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.object
+    }
+}
+
+impl DerefMut for Window {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.object
+    }
+}
+
+/// A wrapper around Window that automatically deletes the window when dropped.
+pub struct OwnedWindow(NonNull<Window>);
+
+impl OwnedWindow {
+    pub fn new(window: NonNull<Window>) -> Self {
+        Self(window)
+    }
+}
+
+impl From<NonNull<Window>> for OwnedWindow {
+    fn from(window: NonNull<Window>) -> Self {
+        Self::new(window)
+    }
+}
+
+impl Into<NonNull<Window>> for OwnedWindow {
+    fn into(self) -> NonNull<Window> {
+        let this = ManuallyDrop::new(self);
+        this.0
+    }
+}
+
+impl Drop for OwnedWindow {
+    fn drop(&mut self) {
+        synchronous_lock!({
+            unsafe {
+                self.0.as_mut().delete();
+            }
+        });
+    }
+}
+
+impl Deref for OwnedWindow {
+    type Target = Window;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl DerefMut for OwnedWindow {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { self.0.as_mut() }
     }
 }

--- a/modules/graphics/src/window.rs
+++ b/modules/graphics/src/window.rs
@@ -3,7 +3,7 @@ use crate::{Color, Error, EventKind, Key, Result, event::Event, synchronous_lock
 use alloc::collections::VecDeque;
 use core::{
     future::poll_fn,
-    mem::{ManuallyDrop, forget},
+    mem::ManuallyDrop,
     ops::{Deref, DerefMut},
     ptr::{self, NonNull},
     str,
@@ -67,7 +67,7 @@ unsafe extern "C" fn window_constructor(
             &mut (*window).event_queue,
             VecDeque::with_capacity(WINDOW_QUEUE_DEFAULT_CAPACITY),
         );
-        ptr::write(&mut (*window).icon_text, [b'W', b'i']);
+        ptr::write(&mut (*window).icon_text, *b"Wi");
         ptr::write(&mut (*window).icon_color, Color::BLACK);
         ptr::write(&mut (*window).waker_registration, AtomicWaker::new());
 
@@ -305,9 +305,9 @@ impl From<NonNull<Window>> for OwnedWindow {
     }
 }
 
-impl Into<NonNull<Window>> for OwnedWindow {
-    fn into(self) -> NonNull<Window> {
-        let this = ManuallyDrop::new(self);
+impl From<OwnedWindow> for NonNull<Window> {
+    fn from(val: OwnedWindow) -> Self {
+        let this = ManuallyDrop::new(val);
         this.0
     }
 }

--- a/modules/graphics/tests/graphics.rs
+++ b/modules/graphics/tests/graphics.rs
@@ -54,9 +54,9 @@ async fn main() {
         .await
         .unwrap();
 
-    let window = graphics.create_window().await.unwrap();
+    let mut window = graphics.create_window().await.unwrap();
 
-    let window = window.into_raw();
+    let window = window.as_object_mutable();
 
     let _calendar = unsafe { lvgl::lv_calendar_create(window) };
 

--- a/modules/task/src/manager/utilities.rs
+++ b/modules/task/src/manager/utilities.rs
@@ -16,14 +16,11 @@ impl Manager {
         RawIdentifier: Debug,
     {
         for key in map.keys() {
-            match range.next() {
-                Some(test_key) => {
-                    if *key != test_key {
-                        return Some(test_key.into());
-                    }
+            {
+                let test_key = range.next()?;
+                if *key != test_key {
+                    return Some(test_key.into());
                 }
-
-                None => return None, // No more identifiers to check
             }
         }
 

--- a/modules/virtual_file_system/src/file_system/mod.rs
+++ b/modules/virtual_file_system/src/file_system/mod.rs
@@ -175,14 +175,14 @@ impl VirtualFileSystem {
                 unsafe { Box::from_raw(file_system.file_system as *const _ as *mut _) };
         }
 
-        for (_, block_device) in block_devices.iter_mut() {
+        for block_device in block_devices.values_mut() {
             block_device.device.unmount()?;
             let _: Box<dyn BlockDevice> =
                 unsafe { Box::from_raw(block_device.device as *const _ as *mut _) };
         }
         block_devices.clear();
 
-        for (_, character_device) in character_devices.iter_mut() {
+        for character_device in character_devices.values_mut() {
             character_device.device.unmount()?;
             let _: Box<dyn CharacterDevice> =
                 unsafe { Box::from_raw(character_device.device as *const _ as *mut _) };


### PR DESCRIPTION
This pull request refactors the codebase to consistently use the new `OwnedWindow` abstraction in place of the previous `Window` type across multiple modules. It also modernizes control flow by adopting Rust's let-chaining (`if ... && let ...`) and improves code readability by simplifying match and event handling patterns. The changes enhance maintainability, safety, and consistency in UI window management and event processing.

**Refactoring to `OwnedWindow` abstraction:**

* Replaced usage of the `Window` type with `OwnedWindow` in the `FileManager`, `Settings`, `Desk`, and `Login` structs, updating all associated window method calls to use `as_object_mutable()` or `as_mut()` as appropriate. [[1]](diffhunk://#diff-a75d455434caa56d5729d0c661e75d3398d79c177e1c1699d2b6561932d2c7bfL9-R22) [[2]](diffhunk://#diff-a75d455434caa56d5729d0c661e75d3398d79c177e1c1699d2b6561932d2c7bfL66-R74) [[3]](diffhunk://#diff-a75d455434caa56d5729d0c661e75d3398d79c177e1c1699d2b6561932d2c7bfL106-L110) [[4]](diffhunk://#diff-a75d455434caa56d5729d0c661e75d3398d79c177e1c1699d2b6561932d2c7bfL136-R136) [[5]](diffhunk://#diff-a75d455434caa56d5729d0c661e75d3398d79c177e1c1699d2b6561932d2c7bfL226-R226) [[6]](diffhunk://#diff-1ec65bb0c09489a0995d4d07ff9663cbefbddc2205105dab3146e627f3baaf2eR3-R13) [[7]](diffhunk://#diff-1ec65bb0c09489a0995d4d07ff9663cbefbddc2205105dab3146e627f3baaf2eL33-R34) [[8]](diffhunk://#diff-1ec65bb0c09489a0995d4d07ff9663cbefbddc2205105dab3146e627f3baaf2eL63-R64) [[9]](diffhunk://#diff-c7bf08b9dc380b6fa2db4d92e311bf197f2f5507547cd1f1512c54da497e1c35L15-R15) [[10]](diffhunk://#diff-c7bf08b9dc380b6fa2db4d92e311bf197f2f5507547cd1f1512c54da497e1c35L29-R29) [[11]](diffhunk://#diff-c7bf08b9dc380b6fa2db4d92e311bf197f2f5507547cd1f1512c54da497e1c35L75-R76) [[12]](diffhunk://#diff-c7bf08b9dc380b6fa2db4d92e311bf197f2f5507547cd1f1512c54da497e1c35L92-R105) [[13]](diffhunk://#diff-c7bf08b9dc380b6fa2db4d92e311bf197f2f5507547cd1f1512c54da497e1c35L136-R136) [[14]](diffhunk://#diff-c7bf08b9dc380b6fa2db4d92e311bf197f2f5507547cd1f1512c54da497e1c35L356-R356) [[15]](diffhunk://#diff-d89be6b13b1b28ecf47bb5461f5e1afec520d7fc817d65a3f31a4ef6a2faece6L1-R4) [[16]](diffhunk://#diff-d89be6b13b1b28ecf47bb5461f5e1afec520d7fc817d65a3f31a4ef6a2faece6L14-R13) [[17]](diffhunk://#diff-d89be6b13b1b28ecf47bb5461f5e1afec520d7fc817d65a3f31a4ef6a2faece6L27-R31) [[18]](diffhunk://#diff-d89be6b13b1b28ecf47bb5461f5e1afec520d7fc817d65a3f31a4ef6a2faece6L41-R40) [[19]](diffhunk://#diff-d89be6b13b1b28ecf47bb5461f5e1afec520d7fc817d65a3f31a4ef6a2faece6L54-R53)

**Modernizing control flow and event handling:**

* Adopted Rust's let-chaining (`if ... && let ...`) for more concise and readable conditional logic in functions like `split_host_port` and `render_cpuinfo_text`. [[1]](diffhunk://#diff-258c796725d82bc73a8da89a0b9a33e12b42f53fd60ec7bdc158d5b96a654b3fL25-L44) [[2]](diffhunk://#diff-2ea51a773de418f7729ee9ddb2d5005a49ba29a7727fe70c77ef0e31e59c9a4aL102-L106)
* Refactored match arms and event handlers to use guard patterns, reducing nesting and improving clarity in event-driven code, especially in the `Desk` and `screen_event_handler` implementations. [[1]](diffhunk://#diff-c7bf08b9dc380b6fa2db4d92e311bf197f2f5507547cd1f1512c54da497e1c35L563-R569) [[2]](diffhunk://#diff-c7bf08b9dc380b6fa2db4d92e311bf197f2f5507547cd1f1512c54da497e1c35L671-R669) [[3]](diffhunk://#diff-c7bf08b9dc380b6fa2db4d92e311bf197f2f5507547cd1f1512c54da497e1c35L682-R691) [[4]](diffhunk://#diff-c7bf08b9dc380b6fa2db4d92e311bf197f2f5507547cd1f1512c54da497e1c35L709) [[5]](diffhunk://#diff-f93ee0f9c3aae8b47d6dce81bb83a4d9b8825486e5e06f72de60ebe5c4168ea7L91-L106)

**Code cleanup and minor improvements:**

* Simplified match expressions and removed unnecessary nesting in command dispatch and event handling logic.
* Reorganized imports and updated usages to align with the new abstractions and code structure. [[1]](diffhunk://#diff-a75d455434caa56d5729d0c661e75d3398d79c177e1c1699d2b6561932d2c7bfL9-R22) [[2]](diffhunk://#diff-d89be6b13b1b28ecf47bb5461f5e1afec520d7fc817d65a3f31a4ef6a2faece6L1-R4)

These changes collectively improve code consistency, readability, and future maintainability by unifying window management and adopting modern Rust idioms.